### PR TITLE
Add charts location feature for downloading remote git releases files

### DIFF
--- a/pkg/havener/errors.go
+++ b/pkg/havener/errors.go
@@ -27,9 +27,28 @@ type NoHelmChartFoundError struct {
 	Location string
 }
 
+// invalidPathInsideZip means that the path does not exists in the zip file
+type invalidPathInsideZip struct {
+	fileName string
+	path     string
+}
+
+// invalidZipFileName means that the file is not of the form <file-name>.zip
+type invalidZipFileName struct {
+	fileName string
+}
+
 func (e *NoHelmChartFoundError) Error() string {
 	return fmt.Sprintf("unable to determine Helm Chart location of '%s', it is not a local path, nor is it defined in %s or %s",
 		e.Location,
 		chartRoomURL,
 		helmChartsURL)
+}
+
+func (e *invalidPathInsideZip) Error() string {
+	return fmt.Sprintf("Error: The provided path: %v, does not exist under the %v file", e.fileName, e.path)
+}
+
+func (e *invalidZipFileName) Error() string {
+	return fmt.Sprintf("Error: The provided file under the %v URL, is not a valid zip file.", e.fileName)
 }

--- a/pkg/havener/locations.go
+++ b/pkg/havener/locations.go
@@ -21,15 +21,20 @@
 package havener
 
 import (
+	"archive/zip"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	git "gopkg.in/src-d/go-git.v4"
 )
 
 const chartRoomURL = "https://github.com/homeport/chartroom"
 const helmChartsURL = "https://github.com/helm/charts"
+const downloadedCharts = "/extracted"
 
 func havenerHomeDir() string {
 	return HomeDir() + "/.havener"
@@ -89,22 +94,143 @@ func cloneOrPull(location string, url string) error {
 	return nil
 }
 
+//unzipArtifactFile will extract and copy a desired path under a zip file
+//into ~/.havener/extracted
+func unzipArtifactFile(filePath string, insidePath string) (string, error) {
+	destinatedLocation := havenerHomeDir() + downloadedCharts
+
+	// os.RemoveAll(destinatedLocation)
+
+	r, err := zip.OpenReader(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := r.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	for _, f := range r.Reader.File {
+		zip, _ := f.Open()
+		defer zip.Close()
+		path := filepath.Join(destinatedLocation, f.Name)
+
+		//only open files if the current path is a substring of the
+		//desired location
+		if strings.Contains(path, destinatedLocation+"/"+insidePath) {
+			if f.FileInfo().IsDir() {
+				os.MkdirAll(path, f.Mode())
+			} else {
+				f, err := os.OpenFile(
+					path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
+				if err != nil {
+					return "", err
+				}
+				defer f.Close()
+				_, err = io.Copy(f, zip)
+				if err != nil {
+					return "", err
+				}
+			}
+		}
+	}
+
+	//if location under ~/.havener/extracted is empty, return an error
+	if _, err := os.Stat(destinatedLocation); os.IsNotExist(err) {
+		return "", &invalidPathInsideZip{insidePath, filePath}
+	}
+	return destinatedLocation + "/" + insidePath, err
+}
+
+// downloadArtifact returns a path that points to a location locally
+// where an specific path of an extracted file was copied.
+func downloadArtifact(artifactURL string, artifactPath string) (string, error) {
+	var file string
+
+	//grab the leftmost match of the provided path,
+	//this should give you the compressed file name
+	//see https://regex101.com/r/5r3n6u/1
+	shellRegexArtifact := regexp.MustCompile(`[^/]+[.zip]$`)
+	if matches := shellRegexArtifact.FindStringSubmatch(artifactURL); len(matches) > 0 {
+		file = matches[0]
+	} else {
+		return "", &invalidZipFileName{artifactURL}
+	}
+
+	if _, err := os.Stat(havenerHomeDir()); os.IsNotExist(err) {
+		os.MkdirAll(havenerHomeDir(), os.ModePerm)
+	}
+
+	output, err := os.Create(havenerHomeDir() + "/" + file)
+	if err != nil {
+		return "", err
+	}
+	defer output.Close()
+
+	resp, err := http.Get(artifactURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	_, err = io.Copy(output, resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	localPath, err := unzipArtifactFile(havenerHomeDir()+"/"+file, artifactPath)
+	if err != nil {
+		return "", err
+	}
+
+	return localPath, nil
+}
+
+// validateRegex returns a boolean if the regular expression matches the input.
+func validateRegex(regexExpression *regexp.Regexp, input string) bool {
+	if matches := regexExpression.FindAllStringSubmatch(input, -1); len(matches) > 0 {
+		return true
+	}
+	return false
+}
+
 // PathToHelmChart returns an absolute path to the location of the Helm Chart
 // directory refereced by the input string. In case the path cannot be found
 // locally in the file system, Git repositories containing curated lists of
 // Helm Charts will be cloned into the Havener app directory and searched for
 // the provided location, too.
 func PathToHelmChart(input string) (string, error) {
+	var artifactPath string
+	var artifactURL string
+
 	// Return the absolute path if the input is actually an existing local location
 	if isHelmChartLocation(input) {
 		return filepath.Abs(input)
 	}
 
+	// Each switch case applies an specific regular expression for an expected input.
+	switch {
+	// Only try to git clone a chart that follows the correct syntax.
+	// syntax is <path-inside-compressed-file>@<url-to-compressed-file>, example:
+	// helm/cf-opensuse@https://github.com/SUSE/scf/releases/download/2.13.3/scf-opensuse-2.13.3+cf2.7.0.0.gf95d9aed.zip
+	// see https://regex101.com/r/5r3n6u/2
+	case validateRegex(regexp.MustCompile(`^(.+)[@](.+)$`), input):
+		matches := regexp.MustCompile(`^(.+)[@](.+)$`).FindAllStringSubmatch(input, -1)
+		for _, match := range matches {
+			artifactPath = match[1]
+			artifactURL = match[2]
+		}
+		localPath, error := downloadArtifact(artifactURL, artifactPath)
+		if error != nil {
+			return "", error
+		}
+		return filepath.Abs(localPath)
+
 	// Only try to git clone a chart that follows the correct syntax.
 	// example valid paths: "tomcat/stable", "scf/2.14.1"
 	// example invalid paths: "/tomcat/stable", "tomcat/stable/", "tomcat/stable/dev"
-	shellRegexp := regexp.MustCompile(`^[\w\d-]+\/[\w\d._-]+$`)
-	if matches := shellRegexp.FindAllStringSubmatch(input, -1); len(matches) > 0 {
+	case validateRegex(regexp.MustCompile(`^[\w\d-]+\/[\w\d._-]+$`), input):
 		// Update Git repos with curated applications for Kubernetes
 		if err := updateLocalChartStore(); err != nil {
 			return "", err
@@ -116,9 +242,10 @@ func PathToHelmChart(input string) (string, error) {
 				return filepath.Abs(candidate)
 			}
 		}
+		return "", &NoHelmChartFoundError{Location: input}
+	default:
+		return "", &NoHelmChartFoundError{Location: input}
 	}
-
-	return "", &NoHelmChartFoundError{Location: input}
 }
 
 func isHelmChartLocation(path string) bool {

--- a/pkg/havener/locations_test.go
+++ b/pkg/havener/locations_test.go
@@ -81,6 +81,48 @@ var _ = Describe("Charts Locations", func() {
 				Expect(err.Error()).Should(Equal(constructedError))
 			})
 		})
+		Context("when the Helm Chart exists as a zip file in a github release", func() {
+			JustBeforeEach(func() {
+				os.Setenv("HOME", "/tmp/home")
+			})
+			AfterEach(func() {
+				os.RemoveAll(os.Getenv("HOME"))
+				os.Unsetenv("HOME")
+			})
+
+			It("should download cf chart, extract and place it under the ~/.havener dir", func() {
+				path, _ := havener.PathToHelmChart("helm/cf-opensuse@https://github.com/SUSE/scf/releases/download/2.13.3/scf-opensuse-2.13.3+cf2.7.0.0.gf95d9aed.zip")
+				Expect(path).Should(Equal("/tmp/home/.havener/extracted/helm/cf-opensuse"))
+			})
+		})
+		Context("when the Helm Chart zip file location contains an invalid dir path", func() {
+			JustBeforeEach(func() {
+				os.Setenv("HOME", "/tmp/home-invalid-path")
+			})
+			AfterEach(func() {
+				os.RemoveAll(os.Getenv("HOME"))
+				os.Unsetenv("HOME")
+			})
+			It("should throw an error regarding the unexisting path", func() {
+				_, err := havener.PathToHelmChart("foo/bar@https://github.com/SUSE/scf/releases/download/2.13.3/scf-opensuse-2.13.3+cf2.7.0.0.gf95d9aed.zip")
+				constructedError := "Error: The provided path: foo/bar, does not exist under the /tmp/home-invalid-path/.havener/scf-opensuse-2.13.3+cf2.7.0.0.gf95d9aed.zip file"
+				Expect(err.Error()).Should(Equal(constructedError))
+			})
+		})
+		Context("when the Helm Chart zip file location does not contains a .zip file", func() {
+			JustBeforeEach(func() {
+				os.Setenv("HOME", "/tmp/home-invalid-file")
+			})
+			AfterEach(func() {
+				os.Unsetenv("HOME")
+			})
+			It("should not download, throw an error regarding the invalid zip file", func() {
+				_, err := havener.PathToHelmChart("helm/cf-opensuse@https://github.com/SUSE/scf/releases/download/2.13.3/scf-opensuse-2.13.3+cf2.7.0.0.gf95d9aed")
+				constructedError := "Error: The provided file under the https://github.com/SUSE/scf/releases/download/2.13.3/scf-opensuse-2.13.3+cf2.7.0.0.gf95d9aed URL, is not a valid zip file."
+				Expect(err.Error()).Should(Equal(constructedError))
+			})
+		})
+
 	})
 })
 


### PR DESCRIPTION
The format to enable this, follows the syntax:
- `path-inside-zip-file@zip-file-URL`

for example:
- `helm/cf-opensuse@https://github.com/SUSE/scf/releases/download/2.13.3/scf-opensuse-2.13.3+cf2.7.0.0.gf95d9aed.zip`

Currently, only supporting zip files