### PR TITLE
Refactor log message functions

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -49,7 +49,7 @@ var deployCmd = &cobra.Command{
 
 		// If a config file is found, read it in.
 		if err := viper.ReadInConfig(); err == nil {
-			havener.InfoMessage(fmt.Sprintf("Using config file: %s", viper.ConfigFileUsed()))
+			havener.InfoMessage("Using config file: %s", viper.ConfigFileUsed())
 		}
 
 		havener.VerboseMessage("Reading config file...")
@@ -93,7 +93,7 @@ var deployCmd = &cobra.Command{
 			}
 			s.Stop()
 
-			havener.InfoMessage(fmt.Sprintf("Successfully created new helm chart for %s in namespace %s.", release.ChartName, release.ChartNamespace))
+			havener.InfoMessage("Successfully created new helm chart for %s in namespace %s.", release.ChartName, release.ChartNamespace)
 		}
 	},
 }

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -47,7 +47,7 @@ var upgradeCmd = &cobra.Command{
 
 		// If a config file is found, read it in.
 		if err := viper.ReadInConfig(); err == nil {
-			havener.InfoMessage(fmt.Sprintf("Using config file: %s", viper.ConfigFileUsed()))
+			havener.InfoMessage("Using config file: %s", viper.ConfigFileUsed())
 		}
 
 		havener.VerboseMessage("Reading config file...")
@@ -80,13 +80,13 @@ var upgradeCmd = &cobra.Command{
 				havener.ExitWithError("failed to marshal overrides structure into bytes", err)
 			}
 
-			havener.InfoMessage(fmt.Sprintf("Going to upgrade existing %s chart...", release.ChartName))
+			havener.InfoMessage("Going to upgrade existing %s chart...", release.ChartName)
 
 			if _, err := havener.UpdateHelmRelease(release.ChartName, release.ChartLocation, overridesData, reuseValues); err != nil {
 				havener.ExitWithError("Error updating chart", err)
 			}
 
-			havener.InfoMessage(fmt.Sprintf("Successfully upgraded existing %s chart.", release.ChartName))
+			havener.InfoMessage("Successfully upgraded existing %s chart.", release.ChartName)
 		}
 
 	},

--- a/pkg/havener/common.go
+++ b/pkg/havener/common.go
@@ -76,13 +76,13 @@ func ExitWithError(msg string, err error) {
 }
 
 // VerboseMessage prints a message if the flag --verbose/-v is set to true
-func VerboseMessage(message string) {
+func VerboseMessage(message string, vargs ...interface{}) {
 	if viper.GetBool("verbose") {
-		fmt.Printf(bunt.BoldText("[DEBUG] " + message + "\n"))
+		fmt.Printf(bunt.BoldText("[DEBUG] " + fmt.Sprintf(message, vargs...) + "\n"))
 	}
 }
 
 // InfoMessage prints out an info message, in bold
-func InfoMessage(message string) {
-	fmt.Printf(bunt.BoldText("[INFO] " + message + "\n"))
+func InfoMessage(message string, vargs ...interface{}) {
+	fmt.Printf(bunt.BoldText("[INFO] " + fmt.Sprintf(message, vargs...) + "\n"))
 }

--- a/pkg/havener/helm.go
+++ b/pkg/havener/helm.go
@@ -127,7 +127,7 @@ func DeployHelmRelease(chartname string, namespace string, chartPath string, val
 		ExitWithError("Unable to locate helm chart location", err)
 	}
 
-	VerboseMessage(fmt.Sprintf("Loading chart in namespace %s...", namespace))
+	VerboseMessage("Loading chart in namespace %s...", namespace)
 
 	chartRequested, err := GetHelmChart(helmChartPath)
 	if err != nil {
@@ -141,7 +141,7 @@ func DeployHelmRelease(chartname string, namespace string, chartPath string, val
 		return nil, err
 	}
 
-	VerboseMessage(fmt.Sprintf("Installing release in namespace %s...", namespace))
+	VerboseMessage("Installing release in namespace %s...", namespace)
 
 	installRelease, err := helmClient.InstallReleaseFromChart(
 		chartRequested,

--- a/pkg/havener/verifier.go
+++ b/pkg/havener/verifier.go
@@ -59,7 +59,7 @@ func VerifyCertExpirations() (err error) {
 	}
 
 	for _, namespace := range list {
-		VerboseMessage(fmt.Sprintf("Getting secrets of namespace %s...", namespace))
+		VerboseMessage("Getting secrets of namespace %s...", namespace)
 
 		secretList, err := ListSecretsInNamespace(client, namespace)
 		if err != nil {
@@ -67,11 +67,11 @@ func VerifyCertExpirations() (err error) {
 		}
 
 		if len(list) == 0 {
-			VerboseMessage(fmt.Sprintf("No secrets in namespace %s", namespace))
+			VerboseMessage("No secrets in namespace %s", namespace)
 		}
 
 		for _, secret := range secretList {
-			VerboseMessage(fmt.Sprintf("Accessing secret %s of namespace %s...", secret, namespace))
+			VerboseMessage("Accessing secret %s of namespace %s...", secret, namespace)
 
 			nodeList, err := client.CoreV1().Secrets(namespace).Get(secret, v1.GetOptions{})
 			if err != nil {
@@ -102,9 +102,9 @@ func VerifyCertExpirations() (err error) {
 				buf.WriteString(line)
 			}
 			if len(results) == 0 {
-				VerboseMessage(fmt.Sprintf("No certificates in secret %s\n", secret))
+				VerboseMessage("No certificates in secret %s\n", secret)
 			} else {
-				VerboseMessage(fmt.Sprintf("Total nr. of certs in secret %s in namespace %s: %v; valid: %v; invalid: %v; empty: %v\n", secret, namespace, len(results), len(results)-count-countEmpty, count, countEmpty))
+				VerboseMessage("Total nr. of certs in secret %s in namespace %s: %v; valid: %v; invalid: %v; empty: %v\n", secret, namespace, len(results), len(results)-count-countEmpty, count, countEmpty)
 			}
 
 		}


### PR DESCRIPTION
VerboseMessage and InfoMessage now take vargs and format strings, so the
argument doesn't need to be formatted beforehand anymore.