### PR TITLE
Improve purge behaviour

### DIFF
--- a/pkg/havener/errors.go
+++ b/pkg/havener/errors.go
@@ -20,7 +20,15 @@
 
 package havener
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+)
+
+// MultipleErrors is used when one or more errors can occur in one function
+type MultipleErrors struct {
+	ListOfErrors []error
+}
 
 // NoHelmChartFoundError means that no Helm Charts were found at a given location
 type NoHelmChartFoundError struct {
@@ -36,6 +44,21 @@ type invalidPathInsideZip struct {
 // invalidZipFileName means that the file is not of the form <file-name>.zip
 type invalidZipFileName struct {
 	fileName string
+}
+
+func (e *MultipleErrors) Error() string {
+	var buf bytes.Buffer
+
+	if len(e.ListOfErrors) > 0 {
+		buf.WriteString("multiple errors occurred:\n")
+		for _, err := range e.ListOfErrors {
+			buf.WriteString(" - ")
+			buf.WriteString(err.Error())
+			buf.WriteString("\n")
+		}
+	}
+
+	return buf.String()
 }
 
 func (e *NoHelmChartFoundError) Error() string {


### PR DESCRIPTION
During purge of a Helm Release, collect the errors until everything is
done. In case errors are occurred, return them as a bundled error.

Improve purge of namespaces by checking whether the namespace is already
deleted (skip rest of the function), or if the namespace is already in
Phase Terminating (also, skip rest of the function).

This should fix #25 