### PR TITLE
Move ExitWithError function into internal package

### DIFF
--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/homeport/gonvenience/pkg/v1/bunt"
 )
 
 // NoUserPrompt defines whether a user confirmation is required or should be omitted
@@ -51,4 +53,17 @@ func PromptUser(message string) bool {
 	}
 
 	return false
+}
+
+// exitWithError leaves the tool with the provided error message
+func exitWithError(msg string, err error) {
+	bunt.Printf("Coral{*%s*}\n", msg)
+
+	if err != nil {
+		for _, line := range strings.Split(err.Error(), "\n") {
+			bunt.Printf("Coral{│} DimGray{%s}\n", line)
+		}
+	}
+
+	os.Exit(1)
 }

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -45,7 +45,7 @@ var logsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		clientSet, restconfig, err := havener.OutOfClusterAuthentication()
 		if err != nil {
-			havener.ExitWithError("unable to get access to cluster", err)
+			exitWithError("unable to get access to cluster", err)
 		}
 
 		var commonText string
@@ -70,12 +70,12 @@ var logsCmd = &cobra.Command{
 		case err := <-resultChan:
 			if err != nil {
 				pi.Done()
-				havener.ExitWithError("unable to retrieve logs from pods", err)
+				exitWithError("unable to retrieve logs from pods", err)
 			}
 
 		case <-time.After(timeout):
 			pi.Done()
-			havener.ExitWithError("unable to retrieve logs from pods", fmt.Errorf("download did not finish within configured timeout"))
+			exitWithError("unable to retrieve logs from pods", fmt.Errorf("download did not finish within configured timeout"))
 		}
 
 		pi.Done("Done downloading " + commonText + ": " + filepath.Join(downloadLocation, havener.LogDirName))

--- a/internal/cmd/nexec.go
+++ b/internal/cmd/nexec.go
@@ -50,13 +50,13 @@ and respective pod will be deleted after the command was executed.
 
 		client, restconfig, err := havener.OutOfClusterAuthentication()
 		if err != nil {
-			havener.ExitWithError("failed to connect to Kubernetes cluster", err)
+			exitWithError("failed to connect to Kubernetes cluster", err)
 		}
 
 		havener.VerboseMessage("Executing command on node...")
 
 		if err := havener.NodeExec(client, restconfig, nodeName, command, os.Stdin, os.Stdout, os.Stderr, nodeExecTty); err != nil {
-			havener.ExitWithError("failed to execute command on node", err)
+			exitWithError("failed to execute command on node", err)
 		}
 
 		havener.VerboseMessage("Successfully executed command.")

--- a/internal/cmd/purge.go
+++ b/internal/cmd/purge.go
@@ -57,11 +57,11 @@ If multiple Helm Releases are specified, then they will deleted concurrently.
 
 		client, _, err := havener.OutOfClusterAuthentication()
 		if err != nil {
-			havener.ExitWithError("unable to get access to cluster", err)
+			exitWithError("unable to get access to cluster", err)
 		}
 
 		if err := purgeHelmReleases(client, getConfiguredHelmClient(), args...); err != nil {
-			havener.ExitWithError("failed to purge helm releases", err)
+			exitWithError("failed to purge helm releases", err)
 		}
 	},
 }
@@ -72,14 +72,14 @@ func getConfiguredHelmClient() *helm.Client {
 
 	cfg, err := ioutil.ReadFile(viper.GetString("kubeconfig"))
 	if err != nil {
-		havener.ExitWithError("unable to read the kube config file", err)
+		exitWithError("unable to read the kube config file", err)
 	}
 
 	havener.VerboseMessage("Getting helm client...")
 
 	helmClient, err := havener.GetHelmClient(cfg)
 	if err != nil {
-		havener.ExitWithError("failed to get helm client", err)
+		exitWithError("failed to get helm client", err)
 	}
 
 	return helmClient

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -30,8 +30,6 @@ import (
 
 	"github.com/homeport/gonvenience/pkg/v1/term"
 	"github.com/mitchellh/go-homedir"
-
-	"github.com/homeport/havener/pkg/havener"
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -59,7 +57,7 @@ func Execute() {
 func init() {
 	home, err := homedir.Dir()
 	if err != nil {
-		havener.ExitWithError("unable to get home directory", err)
+		exitWithError("unable to get home directory", err)
 	}
 
 	rootCmd.Flags().SortFlags = false

--- a/internal/cmd/top.go
+++ b/internal/cmd/top.go
@@ -37,7 +37,7 @@ var topCmd = &cobra.Command{
 
 		clientSet, _, err := havener.OutOfClusterAuthentication()
 		if err != nil {
-			havener.ExitWithError("unable to get access to cluster", err)
+			exitWithError("unable to get access to cluster", err)
 		}
 
 		havener.ShowTopStats(clientSet)

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -42,7 +42,7 @@ var upgradeCmd = &cobra.Command{
 		havener.VerboseMessage("Looking for config file...")
 
 		if cfgFile == "" && viper.GetString("havenerconfig") == "" {
-			havener.ExitWithError("please provide configuration via --config or environment variable HAVENERCONFIG", fmt.Errorf("no havener configuration file set"))
+			exitWithError("please provide configuration via --config or environment variable HAVENERCONFIG", fmt.Errorf("no havener configuration file set"))
 		}
 
 		// If a config file is found, read it in.
@@ -54,14 +54,14 @@ var upgradeCmd = &cobra.Command{
 
 		cfgdata, err := ioutil.ReadFile(viper.GetString("havenerconfig"))
 		if err != nil {
-			havener.ExitWithError("unable to read file", err)
+			exitWithError("unable to read file", err)
 		}
 
 		havener.VerboseMessage("Unmarshaling config file...")
 
 		var config havener.Config
 		if err := yaml.Unmarshal(cfgdata, &config); err != nil {
-			havener.ExitWithError("failed to unmarshal config file", err)
+			exitWithError("failed to unmarshal config file", err)
 		}
 
 		for _, release := range config.Releases {
@@ -70,20 +70,20 @@ var upgradeCmd = &cobra.Command{
 			havener.VerboseMessage("Processing overrides section...")
 
 			if err != nil {
-				havener.ExitWithError("failed to process overrides section", err)
+				exitWithError("failed to process overrides section", err)
 			}
 
 			havener.VerboseMessage("Marshaling overrides section...")
 
 			overridesData, err := yaml.Marshal(overrides)
 			if err != nil {
-				havener.ExitWithError("failed to marshal overrides structure into bytes", err)
+				exitWithError("failed to marshal overrides structure into bytes", err)
 			}
 
 			havener.InfoMessage("Going to upgrade existing %s chart...", release.ChartName)
 
 			if _, err := havener.UpdateHelmRelease(release.ChartName, release.ChartLocation, overridesData, reuseValues); err != nil {
-				havener.ExitWithError("Error updating chart", err)
+				exitWithError("Error updating chart", err)
 			}
 
 			havener.InfoMessage("Successfully upgraded existing %s chart.", release.ChartName)

--- a/pkg/havener/common.go
+++ b/pkg/havener/common.go
@@ -52,7 +52,7 @@ func OutOfClusterAuthentication() (*kubernetes.Clientset, *rest.Config, error) {
 	// url or a kubeconfig filepath.
 	config, err := clientcmd.BuildConfigFromFlags("", getKubeConfig())
 	if err != nil {
-		ExitWithError("Unable to build the config from kubeconfig file", err)
+		return nil, nil, err
 	}
 
 	// create the clientset
@@ -67,12 +67,6 @@ func HomeDir() string {
 		return h
 	}
 	return os.Getenv("USERPROFILE") // windows
-}
-
-// ExitWithError defines a common exit log and exit code
-func ExitWithError(msg string, err error) {
-	fmt.Printf("Message: %s, Error: %s\n", msg, err.Error())
-	os.Exit(1)
 }
 
 // MinutesToSeconds returns the amount of seconds

--- a/pkg/havener/locations_test.go
+++ b/pkg/havener/locations_test.go
@@ -54,9 +54,6 @@ var _ = Describe("Charts Locations", func() {
 				os.Create(fakeChartLocation + "/Chart.yaml")
 				os.Create(fakeChartLocation + "/values.yaml")
 				helmChartPath, err := havener.PathToHelmChart(fakeChartLocation)
-				if err != nil {
-					havener.ExitWithError("Unable to locate helm chart location", err)
-				}
 				Expect(err).Should(BeNil())
 				absolutePath, _ := filepath.Abs(fakeChartLocation)
 				Expect(helmChartPath).Should(Equal(absolutePath))
@@ -65,9 +62,6 @@ var _ = Describe("Charts Locations", func() {
 		Context("when the Helm Chart exists remotely", func() {
 			It("should find a remote chart and place in under the ~/.havener repo", func() {
 				remoteHelmChartPath, err := havener.PathToHelmChart(goodChartTempLocation)
-				if err != nil {
-					havener.ExitWithError("Unable to locate helm chart location", err)
-				}
 				Expect(err).Should(BeNil())
 				absoluteChartPath, _ := filepath.Abs(os.Getenv("HOME") + helmChartTempLocation)
 				Expect(remoteHelmChartPath).Should(Equal(absoluteChartPath))

--- a/pkg/havener/top.go
+++ b/pkg/havener/top.go
@@ -92,7 +92,7 @@ type usageData struct {
 }
 
 // ShowTopStats prints cluster usage statistics
-func ShowTopStats(client kubernetes.Interface) {
+func ShowTopStats(client kubernetes.Interface) error {
 	const nodeCaption = "Node "
 	const processorCaption = "CPU "
 	const memoryCaption = "Memory "
@@ -106,7 +106,7 @@ func ShowTopStats(client kubernetes.Interface) {
 
 	usageData, err := getNodeUsageData(client)
 	if err != nil {
-		ExitWithError("unable to get node usage metrics", err)
+		return err
 	}
 
 	maxLength := 0
@@ -154,7 +154,7 @@ func ShowTopStats(client kubernetes.Interface) {
 
 	podUsage, err := getPodUsageData(client)
 	if err != nil {
-		ExitWithError("unable to get pod usage metrics", err)
+		return err
 	}
 
 	splitKey := func(key string) (string, string, string) {
@@ -216,6 +216,8 @@ func ShowTopStats(client kubernetes.Interface) {
 			fmt.Println(line)
 		}
 	}
+
+	return nil
 }
 
 func getNodeUsageData(client kubernetes.Interface) (map[string]usageData, error) {

--- a/pkg/havener/verifier.go
+++ b/pkg/havener/verifier.go
@@ -28,6 +28,7 @@ import (
 	"regexp"
 
 	"github.com/homeport/gonvenience/pkg/v1/term"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -49,14 +50,14 @@ func VerifyCertExpirations() (err error) {
 
 	client, _, err := OutOfClusterAuthentication()
 	if err != nil {
-		ExitWithError("unable to get access to cluster", err)
+		return errors.Wrap(err, "unable to get access to cluster")
 	}
 
 	VerboseMessage("Getting namespaces...")
 
 	list, err := ListNamespaces(client)
 	if err != nil {
-		ExitWithError("unable to get a list of namespaces", err)
+		return errors.Wrap(err, "unable to get a list of namespaces")
 	}
 
 	for _, namespace := range list {
@@ -64,7 +65,7 @@ func VerifyCertExpirations() (err error) {
 
 		secretList, err := ListSecretsInNamespace(client, namespace)
 		if err != nil {
-			ExitWithError("unable to get a list of secrets", err)
+			return errors.Wrap(err, "unable to get a list of secrets")
 		}
 
 		if len(list) == 0 {
@@ -76,7 +77,7 @@ func VerifyCertExpirations() (err error) {
 
 			nodeList, err := client.CoreV1().Secrets(namespace).Get(secret, v1.GetOptions{})
 			if err != nil {
-				ExitWithError("unable to access secrets", err)
+				return errors.Wrap(err, "unable to access secrets")
 			}
 
 			results := GetCertificateFromSecret(nodeList.Data, namespace, secret)
@@ -112,7 +113,7 @@ func VerifyCertExpirations() (err error) {
 	}
 
 	if count > 0 {
-		ExitWithError("unable to verify certificates", fmt.Errorf("number of failed certs: %d", count))
+		return fmt.Errorf("unable to verify certificates, snumber of failed certs: %d", count)
 	}
 
 	fmt.Print(buf.String())


### PR DESCRIPTION
Move the `ExitWithError` under new name to the internal package and return
errors where needed.

Add some colors to the exit output to look like the following example:
```
Error deploying chart
│ rpc error: code = Unknown desc = a release named tomcat-release already exists.
│ Run: helm ls --all tomcat-release; to check the status of the release
│ Or run: helm del --purge tomcat-release; to delete it
```