### PR TITLE
Introduce pre- and post-deployment steps

### DIFF
--- a/examples/tomcat-deployment.yml
+++ b/examples/tomcat-deployment.yml
@@ -3,3 +3,17 @@ releases:
 - chart_name: tomcat-release
   chart_namespace: tomcat
   chart_location: tomcat/stable
+  before: [echo "$(date) before release"]
+  after: [echo "$(date) after release"]
+
+before:
+- cmd: /bin/bash
+  args:
+  - -c
+  - |
+    #!/bin/bash
+
+    echo "$(date) before deployment"
+
+after:
+- echo "$(date) after deployment"

--- a/pkg/havener/models.go
+++ b/pkg/havener/models.go
@@ -24,6 +24,8 @@ package havener
 type Config struct {
 	Name     string    `yaml:"name"`
 	Releases []Release `yaml:"releases"`
+	Before   *Task     `yaml:"before,omitempty"`
+	After    *Task     `yaml:"after,omitempty"`
 }
 
 // Release is the Havener configuration Helm Release abstraction, which
@@ -34,4 +36,11 @@ type Release struct {
 	ChartLocation  string      `yaml:"chart_location"`
 	ChartVersion   int         `yaml:"chart_version"`
 	Overrides      interface{} `yaml:"overrides"`
+	Before         *Task       `yaml:"before,omitempty"`
+	After          *Task       `yaml:"after,omitempty"`
 }
+
+// Task is the obviously relative generic definition of a list of steps to be
+// evaluated. A task can be configured before and/or after a deployment.
+// Furthermore, a task can also be configured before and/or after each release.
+type Task []interface{}


### PR DESCRIPTION
Add hooks to run arbitrary commands before and/or after a deployment or upgrade.

Add hooks to run commands before and/or after each release/chart.

If output is generated, it will be printed.

![image](https://user-images.githubusercontent.com/1979133/49703461-98990000-fc05-11e8-96c7-98c5741e5eaa.png)

Two kinds of syntaxes are supported:
- Concourse style with command and arguments as part of a map, which is useful for inlining scripts.
- Travis CI style commands as a list syntax.