### PR TITLE
Set Go version to be 1.11.2

### DIFF
--- a/Havener-Alpine.dockerfile
+++ b/Havener-Alpine.dockerfile
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-FROM golang:1.11-alpine AS build
+FROM golang:1.11.2-alpine AS build
 COPY . /go/src/github.com/homeport/havener
 RUN apk add --update make git bash file curl jq && \
   curl -sL https://raw.githubusercontent.com/HeavyWombat/ytbx/master/scripts/download-latest.sh | bash && \

--- a/Havener-Ubuntu.dockerfile
+++ b/Havener-Ubuntu.dockerfile
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-FROM golang:1.11 AS build
+FROM golang:1.11.2 AS build
 COPY . /go/src/github.com/homeport/havener
 RUN apt-get update >/dev/null && \
   apt-get install -y file jq >/dev/null && \


### PR DESCRIPTION
Fix Docker build issue by forcing the Go version in the build step to
exactly match the version used during development and therefore the
same version that wrote the Go modules setup files. There seems to be
an issue in one Go 1.11 version where different Go 1.11 minor versions
write different hashs.