### PR TITLE
Fix staticcheck finding SA1015 - tickers

### DIFF
--- a/internal/cmd/top.go
+++ b/internal/cmd/top.go
@@ -78,6 +78,9 @@ func retrieveClusterStats() error {
 	defer term.ShowCursor()
 
 	iterations := 0
+
+	// lint:ignore SA1015 - In most cases, it is an endless function plus it is
+	// a top level command and therefore the program ends afterwards.
 	for range time.Tick(time.Duration(interval) * time.Second) {
 		// TODO Get stats for nodes and pods at the same time
 		nodeStats, err := hvnr.CompileNodeStats(clientSet)

--- a/pkg/havener/kubexec.go
+++ b/pkg/havener/kubexec.go
@@ -200,11 +200,13 @@ func NodeExec(client kubernetes.Interface, restconfig *rest.Config, node string,
 
 func getPodUsingListOptions(client kubernetes.Interface, namespace string, listOptions metav1.ListOptions) (*corev1.Pod, error) {
 	timeout := time.After(defaultTimeoutForGetPod * time.Second)
-	tick := time.Tick(250 * time.Millisecond)
+
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
 
 	for {
 		select {
-		case <-tick:
+		case <-ticker.C:
 			pods, err := client.CoreV1().Pods(namespace).List(listOptions)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Ignore ticker in top command since the program ends after the ticker
and therefore we do not leak any ticker.

Replaced ticker logic in kube-exec code by using NewTicker instead.