### PR TITLE
Update README to remove mentioning of vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ There are different ways to get `havener`. You are free to pick the one that mak
   go get github.com/homeport/havener/cmd/havener
   ```
 
-  This might take a moment, because `havener` comes with _a lot_ of dependencies in `vendor` that need to be downloaded and compiled as well.
-
 ## Quick Command Overview
 
 Like `kubectl`, `havener` relies on the Kubernetes configuration that can be set via the `KUBECONFIG` environment variable. It can also be provided with the `--kubeconfig` flag, which takes the path to the YAML file (for example `$HOME/.kube/config`). `Havener` will use your local `helm` binary, so it is the user reponsability, to keep the `helm` binary in sync with tiller.


### PR DESCRIPTION
Remove sentence about `vendor` directory since this is not in use anymore.