### PR TITLE
Show output of hook commands in real-time

### DIFF
--- a/examples/tomcat-deployment.yml
+++ b/examples/tomcat-deployment.yml
@@ -14,6 +14,10 @@ before:
     #!/bin/bash
 
     echo "$(date) before deployment"
+    for I in $(seq 1 4); do
+      sleep 1
+      echo "Running ... $(( I * 25 ))%"
+    done
 
 after:
 - echo "$(date) after deployment"


### PR DESCRIPTION
Do not buffer the output of the before/after hooks, but send them directly into
a channel so that they can be consumed at the same time.

Introduce an equivalent styled message streamer to read from a channel to write
the data to the console.

This should fix #80.