### PR TITLE
Remove chart prefixes from configs

### DIFF
--- a/examples/mongodb-config.yml
+++ b/examples/mongodb-config.yml
@@ -1,9 +1,9 @@
 name: mongo deployment
 releases:
-- chart_name: mongodb
-  chart_namespace: mongodb
-  chart_versiion: (( shell echo $VERSION ))
-  chart_location: stable/mongodb
+- name: mongodb
+  namespace: mongodb
+  versiion: (( shell echo $VERSION ))
+  location: stable/mongodb
   overrides:
     mongodbUsername: (( shell echo $USERNAME ))
     mongodbPassword: (( shell echo $PASSWORD ))

--- a/pkg/havener/exec_test.go
+++ b/pkg/havener/exec_test.go
@@ -80,10 +80,10 @@ error message: exit status 127`
 
 		expected := `name: minikube
 releases:
-- chart_name: thgh
-  chart_namespace: abcd
-  chart_location: abcd
-  chart_version: 1
+- name: thgh
+  namespace: abcd
+  location: abcd
+  version: 1
   overrides:
     env:
       DOMAIN: 192.168.99.100.xip.io

--- a/test/correct_environment_test.yml
+++ b/test/correct_environment_test.yml
@@ -1,9 +1,9 @@
 name: minikube
 releases:
-- chart_name: thgh
-  chart_namespace: abcd
-  chart_location: abcd
-  chart_version: 1
+- name: thgh
+  namespace: abcd
+  location: abcd
+  version: 1
   overrides:
     env:
       DOMAIN: (( env SERVICE_DOMAIN ))


### PR DESCRIPTION
This commit removes remaining 'chart_' prefixes from havener
configs after its support was removed in a previous new feature