### PR TITLE
Add local-compile-only option to building of binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,4 +52,7 @@ e2e-test:
 test: lint misspell vet unit-test
 
 build:
-	@scripts/build.sh
+	@scripts/build.sh --local
+
+build-all:
+	@scripts/build.sh --all


### PR DESCRIPTION
The previous 'make build' command got replaced with a new 'make build-all' command
and the 'make build' command only compiles the binary for the local os and
architecture now

Similar to https://github.com/homeport/dyff/blob/develop/scripts/compile-version.sh

Fix #31 