### PR TITLE
Ensure ENV variables can support booleans

### DIFF
--- a/pkg/havener/exec.go
+++ b/pkg/havener/exec.go
@@ -105,7 +105,7 @@ func TraverseStructureAndProcessOperators(input interface{}) (interface{}, error
 // to define booleans in the values.yml, where booleans
 // are supported by helm
 func isPotentialBoolean(input interface{}) bool {
-	shellRegexp := regexp.MustCompile(`(false|true)`)
+	shellRegexp := regexp.MustCompile(`^(false|true)$`)
 	switch obj := input.(type) {
 	case string:
 		if matches := shellRegexp.FindAllStringSubmatch(obj, -1); len(matches) > 0 {

--- a/pkg/havener/exec_test.go
+++ b/pkg/havener/exec_test.go
@@ -87,6 +87,10 @@ releases:
   overrides:
     env:
       DOMAIN: 192.168.99.100.xip.io
+    foo:
+      boolbar: true
+      boolbaredgecase: /some-true/dir/foo
+      boolbarquoted: true
     image:
       pullPolicy: Always
     kube:
@@ -99,7 +103,10 @@ releases:
       UAA_ADMIN_CLIENT_SECRET: secret
 env:
   SERVICE_IP: 192.168.99.100
-  SERVICE_DOMAIN: ((env SERVICE_IP   )).xip.io
+  SERVICE_DOMAIN: (( env SERVICE_IP   )).xip.io
+  BOOLBARQUOTED: "true"
+  BOOLBAR: true
+  BOOLBAREDGECASE: /some-true/dir/foo
 `
 		Expect(string(input2)).To(BeEquivalentTo(expected))
 

--- a/test/correct_environment_test.yml
+++ b/test/correct_environment_test.yml
@@ -7,6 +7,10 @@ releases:
   overrides:
     env:
       DOMAIN: (( env SERVICE_DOMAIN ))
+    foo:
+      boolbar: (( env BOOLBAR ))
+      boolbaredgecase: (( env BOOLBAREDGECASE ))
+      boolbarquoted: (( env BOOLBARQUOTED ))
     image:
       pullPolicy: Always
     kube:
@@ -19,4 +23,7 @@ releases:
       UAA_ADMIN_CLIENT_SECRET: secret
 env:
   SERVICE_IP: 192.168.99.100
-  SERVICE_DOMAIN: ((env SERVICE_IP   )).xip.io
+  SERVICE_DOMAIN: (( env SERVICE_IP   )).xip.io
+  BOOLBARQUOTED: "true"
+  BOOLBAR: true
+  BOOLBAREDGECASE: "/some-true/dir/foo"


### PR DESCRIPTION
Contradictory to what a shell ENV variable type allows

Allow the user to set booleans.

This is to allign us more with what we set in the `values.yml` file.
We know that helm supports `boolean` types in the `values.yml`, so
let´s allow the user to be able to set this values, throught the
ENV vars cmd.