### PR TITLE
Align structure and functionality of node-exec and pod-exec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gonvenience/wrap v1.0.0
 	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/homeport/dyff v0.10.2
 	github.com/homeport/ytbx v1.1.2
 	github.com/imdario/mergo v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
+github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/homeport/dyff v0.10.2 h1:RbjcX69NklnmiyFrmqZ7xyay/gYuTdIpJb38641zyUM=

--- a/pkg/havener/common.go
+++ b/pkg/havener/common.go
@@ -136,14 +136,3 @@ func getSecretValue(namespace string, secretName string, secretKey string) (stri
 
 	return string(secretValue), nil
 }
-
-// sliceContainsStrings checks whether a string slice contains a certain
-// string or not.
-func sliceContainsString(slice []string, item string) bool {
-	for _, entry := range slice {
-		if entry == item {
-			return true
-		}
-	}
-	return false
-}


### PR DESCRIPTION
This commit refactors both commands to have a similar structure and
(error) functionality. Additionally it implements first design decisions
for a distrubuted-shell feature.

Fix #123 