### PR TITLE
Reverse TTY logic

### DIFF
--- a/internal/cmd/nexec.go
+++ b/internal/cmd/nexec.go
@@ -39,7 +39,7 @@ import (
 const nodeDefaultCommand = "/bin/sh"
 
 var (
-	nodeExecTty     bool
+	nodeExecNoTty   bool
 	nodeExecImage   string
 	nodeExecTimeout int
 	nodeExecBlock   bool
@@ -72,7 +72,7 @@ The command can be omitted which will result in the default command: ` + nodeDef
 func init() {
 	rootCmd.AddCommand(nodeExecCmd)
 
-	nodeExecCmd.PersistentFlags().BoolVar(&nodeExecTty, "tty", false, "allocate pseudo-terminal for command execution")
+	nodeExecCmd.PersistentFlags().BoolVar(&nodeExecNoTty, "no-tty", false, "do not allocate pseudo-terminal for command execution")
 	nodeExecCmd.PersistentFlags().StringVar(&nodeExecImage, "image", defaultImage, "set image for helper pod from which the root-shell is accessed")
 	nodeExecCmd.PersistentFlags().IntVar(&nodeExecTimeout, "timeout", defaultTimeout, "set timout in seconds for the setup of the helper pod")
 	nodeExecCmd.PersistentFlags().BoolVar(&nodeExecBlock, "block", false, "show distributed shell output as block for each node")
@@ -126,7 +126,7 @@ func execInClusterNodes(args []string) error {
 				os.Stdin,
 				os.Stdout,
 				os.Stderr,
-				nodeExecTty,
+				!nodeExecNoTty,
 				distributed,
 			)
 			for _, message := range messages {

--- a/internal/cmd/pexec.go
+++ b/internal/cmd/pexec.go
@@ -40,7 +40,7 @@ import (
 const podDefaultCommand = "/bin/sh"
 
 var (
-	podExecTty   bool
+	podExecNoTty bool
 	podExecBlock bool
 )
 
@@ -76,7 +76,7 @@ execute the command in the first container found in the pod.
 func init() {
 	rootCmd.AddCommand(podExecCmd)
 
-	podExecCmd.PersistentFlags().BoolVarP(&podExecTty, "tty", "t", false, "allocate pseudo-terminal for command execution")
+	podExecCmd.PersistentFlags().BoolVar(&podExecNoTty, "no-tty", false, "do not allocate pseudo-terminal for command execution")
 	podExecCmd.PersistentFlags().BoolVar(&podExecBlock, "block", false, "show distributed shell output as block for each pod")
 }
 
@@ -126,7 +126,7 @@ func execInClusterPods(args []string) error {
 					pod,
 					pod.Name,
 					command,
-					podExecTty,
+					!podExecNoTty,
 				)
 				for _, message := range messages {
 					message.Prefix = podName
@@ -142,7 +142,7 @@ func execInClusterPods(args []string) error {
 					os.Stdin,
 					os.Stdout,
 					os.Stderr,
-					podExecTty,
+					!podExecNoTty,
 				)}
 			}
 			wg.Done()


### PR DESCRIPTION
Add `--no-tty` flag to reverse the current default logic. With this change,
by default pseudo terminal allocation is enabled to allow for short commands.