### PR TITLE
Ensure pod deletion on interrupt

### DIFF
--- a/cmd/havener/main.go
+++ b/cmd/havener/main.go
@@ -27,15 +27,22 @@ import (
 
 	"github.com/gonvenience/term"
 	"github.com/homeport/havener/internal/cmd"
+	"github.com/homeport/havener/pkg/havener"
 )
 
 func main() {
+	// Register on operating system signals for an external unexpected exit
 	signals := make(chan os.Signal)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
-
 	go func() {
 		<-signals
+
+		// Make sure that the terminal cursor visibility is restored
 		term.ShowCursor()
+
+		// Notify havener package graceful shutdown function
+		havener.GracefulShutdown()
+
 		os.Exit(1)
 	}()
 

--- a/internal/cmd/nexec.go
+++ b/internal/cmd/nexec.go
@@ -202,14 +202,14 @@ func availableNodesError(client kubernetes.Interface, title string, fArgs ...int
 	if err != nil {
 		return wrap.Error(err, "failed to list all nodes in cluster")
 	}
-	nodeList := []string{}
-	for _, nodeName := range nodes {
-		nodeList = append(nodeList, nodeName)
+
+	if len(nodes) == 0 {
+		return fmt.Errorf("failed to find any node in cluster")
 	}
 
 	return wrap.Errorf(
-		fmt.Errorf("> Usage:\nnode-exec [flags] <node> <command>\n> List of available nodes:\n%s",
-			strings.Join(nodeList, "\n"),
+		fmt.Errorf("List of available nodes:\n%s",
+			strings.Join(nodes, "\n"),
 		),
 		title, fArgs...,
 	)

--- a/pkg/havener/havener.go
+++ b/pkg/havener/havener.go
@@ -28,3 +28,19 @@ runs Cloud Foundry in its containerized version. However, it is not limited to
 this kind of workload.
 */
 package havener
+
+var onShutdownFuncs = []func(){}
+
+// AddShutdownFunction adds a function to be called in case GracefulShutdown is
+// called, for example to clean up resources.
+func AddShutdownFunction(f func()) {
+	onShutdownFuncs = append(onShutdownFuncs, f)
+}
+
+// GracefulShutdown brings down the havener package by going through registered
+// on-shutdown functions.
+func GracefulShutdown() {
+	for _, f := range onShutdownFuncs {
+		f()
+	}
+}

--- a/pkg/havener/purge.go
+++ b/pkg/havener/purge.go
@@ -37,8 +37,6 @@ import (
    provided by the user. Think about making the behaviour configurable: For
    example by introducing a flag like `--ignore-non-existent` or similar. */
 
-/* TODO Make the spinner configurable. */
-
 var defaultPropagationPolicy = metav1.DeletePropagationForeground
 
 // PurgeHelmRelease removes the given helm release including all its resources.
@@ -136,4 +134,15 @@ func PurgeNamespace(kubeClient kubernetes.Interface, namespace string) error {
 	}
 
 	return nil
+}
+
+// PurgePod removes the pod in the given namespace.
+func PurgePod(kubeClient kubernetes.Interface, namespace string, podName string, gracePeriodSeconds int64, propagationPolicy metav1.DeletionPropagation) error {
+	logf(Verbose, "Deleting pod %s in namespace %s", podName, namespace)
+	return kubeClient.CoreV1().Pods(namespace).Delete(
+		podName,
+		&metav1.DeleteOptions{
+			GracePeriodSeconds: &gracePeriodSeconds,
+			PropagationPolicy:  &propagationPolicy,
+		})
 }


### PR DESCRIPTION
Add code to register functions in the havener package to be called in case of a
shutdown event such as as external interrupt.

Add function to delete a pod created for node execution to be used in the
shutdown event scenario.

Fixes #140.