### PR TITLE
Update regex for chart urls to enable omitting of inside path

### DIFF
--- a/pkg/havener/locations.go
+++ b/pkg/havener/locations.go
@@ -206,7 +206,7 @@ func PathToHelmChart(input string) (string, error) {
 	}
 
 	// Each switch case applies an specific regular expression for an expected input.
-	switch urlRegex := regexp.MustCompile(`^((.*)@)?((https://|http://).+)$`); true {
+	switch urlRegex := regexp.MustCompile(`^((.*)@)?((https://|http://).+)$`); {
 	// Only try to git clone a chart that follows the correct syntax.
 	// syntax is <path-inside-compressed-file>@<url-to-compressed-file>, example:
 	// helm/cf-opensuse@https://github.com/SUSE/scf/releases/download/2.13.3/scf-opensuse-2.13.3+cf2.7.0.0.gf95d9aed.zip

--- a/pkg/havener/locations.go
+++ b/pkg/havener/locations.go
@@ -210,12 +210,15 @@ func PathToHelmChart(input string) (string, error) {
 	// Only try to git clone a chart that follows the correct syntax.
 	// syntax is <path-inside-compressed-file>@<url-to-compressed-file>, example:
 	// helm/cf-opensuse@https://github.com/SUSE/scf/releases/download/2.13.3/scf-opensuse-2.13.3+cf2.7.0.0.gf95d9aed.zip
-	// see https://regex101.com/r/5r3n6u/2
-	case validateRegex(regexp.MustCompile(`^(.+)[@](.+)$`), input):
-		matches := regexp.MustCompile(`^(.+)[@](.+)$`).FindAllStringSubmatch(input, -1)
+	// or https://github.com/SUSE/scf/releases/download/2.13.3/scf-opensuse-2.13.3+cf2.7.0.0.gf95d9aed.zip to use the root directory
+	// see https://regex101.com/r/KSpQOf/2
+	case validateRegex(regexp.MustCompile(`^((.*)@)?(.+\b.zip\b)$`), input):
+		matches := regexp.MustCompile(`^((.*)@)?(.+\b.zip\b)$`).FindAllStringSubmatch(input, -1)
 		for _, match := range matches {
-			artifactPath = match[1]
-			artifactURL = match[2]
+			if len(match[2]) > 0 {
+				artifactPath = match[2]
+			}
+			artifactURL = match[3]
 		}
 		localPath, error := downloadArtifact(artifactURL, artifactPath)
 		if error != nil {

--- a/pkg/havener/locations.go
+++ b/pkg/havener/locations.go
@@ -206,14 +206,14 @@ func PathToHelmChart(input string) (string, error) {
 	}
 
 	// Each switch case applies an specific regular expression for an expected input.
-	switch {
+	switch urlRegex := regexp.MustCompile(`^((.*)@)?((https://|http://).+)$`); true {
 	// Only try to git clone a chart that follows the correct syntax.
 	// syntax is <path-inside-compressed-file>@<url-to-compressed-file>, example:
 	// helm/cf-opensuse@https://github.com/SUSE/scf/releases/download/2.13.3/scf-opensuse-2.13.3+cf2.7.0.0.gf95d9aed.zip
 	// or https://github.com/SUSE/scf/releases/download/2.13.3/scf-opensuse-2.13.3+cf2.7.0.0.gf95d9aed.zip to use the root directory
-	// see https://regex101.com/r/KSpQOf/2
-	case validateRegex(regexp.MustCompile(`^((.*)@)?(.+\b.zip\b)$`), input):
-		matches := regexp.MustCompile(`^((.*)@)?(.+\b.zip\b)$`).FindAllStringSubmatch(input, -1)
+	// see https://regex101.com/r/lB7oO0/1
+	case validateRegex(urlRegex, input):
+		matches := urlRegex.FindAllStringSubmatch(input, -1)
 		for _, match := range matches {
 			if len(match[2]) > 0 {
 				artifactPath = match[2]


### PR DESCRIPTION
Changes the regex to make part before @ optional and to check for
.zip extension directly.

**TODO**: I was not able to test this fix in a proper enviroment (for example minikube deployment) yet but only the regex itself and the splitting in the go code. While I doubt that there will be any issues, I full test is from advantage.