### PR TITLE
Extend '--config'-flag with shorter argument option (deploy, upgrade)

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -33,6 +33,7 @@ import (
 )
 
 const (
+	envVarDeployConfig  = "deployment_config"
 	envVarDeployTimeout = "deployment_timeout"
 )
 
@@ -44,9 +45,13 @@ var deployCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		havenerConfig := viper.GetString(envVarDeployConfig)
+
 		switch {
 		case len(args) == 1:
 			return DeployViaHavenerConfig(args[0])
+		case len(havenerConfig) > 0:
+			return DeployViaHavenerConfig(havenerConfig)
 		default:
 			cmd.Usage()
 		}
@@ -58,9 +63,11 @@ var deployCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(deployCmd)
 
+	deployCmd.PersistentFlags().String("config", "", "havener configuration file")
 	deployCmd.PersistentFlags().Int("timeout", 40, "deployment timeout in minutes")
 
 	viper.AutomaticEnv()
+	viper.BindPFlag(envVarDeployConfig, deployCmd.PersistentFlags().Lookup("config"))
 	viper.BindPFlag(envVarDeployTimeout, deployCmd.PersistentFlags().Lookup("timeout"))
 }
 

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -33,27 +33,24 @@ import (
 )
 
 const (
-	envVarDeployConfig  = "deployment_config"
 	envVarDeployTimeout = "deployment_timeout"
 )
 
 // deployCmd represents the deploy command
 var deployCmd = &cobra.Command{
-	Use:           "deploy",
+	Use:           "deploy [havener config file]",
 	Short:         "Deploy to Kubernetes",
 	Long:          `Deploy to Kubernetes based on havener configuration`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		havenerConfig := viper.GetString(envVarDeployConfig)
-
 		switch {
-		case len(havenerConfig) > 0:
-			return DeployViaHavenerConfig(havenerConfig)
-
+		case len(args) == 1:
+			return DeployViaHavenerConfig(args[0])
 		default:
 			cmd.Usage()
 		}
+
 		return nil
 	},
 }
@@ -61,11 +58,9 @@ var deployCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(deployCmd)
 
-	deployCmd.PersistentFlags().String("config", "", "havener configuration file")
 	deployCmd.PersistentFlags().Int("timeout", 40, "deployment timeout in minutes")
 
 	viper.AutomaticEnv()
-	viper.BindPFlag(envVarDeployConfig, deployCmd.PersistentFlags().Lookup("config"))
 	viper.BindPFlag(envVarDeployTimeout, deployCmd.PersistentFlags().Lookup("timeout"))
 }
 

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -33,28 +33,25 @@ import (
 )
 
 const (
-	envVarUpgradeConfig     = "upgrade_config"
 	envVarUpgradeTimeout    = "upgrade_timeout"
 	envVarUpgradeValueReuse = "upgrade_reuse_values"
 )
 
 // upgradeCmd represents the upgrade command
 var upgradeCmd = &cobra.Command{
-	Use:           "upgrade",
+	Use:           "upgrade [havener config file]",
 	Short:         "Upgrade Helm Release in Kubernetes",
 	Long:          `Upgrade Helm Release based on havener configuration`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		havenerUpgradeConfig := viper.GetString(envVarUpgradeConfig)
-
 		switch {
-		case len(havenerUpgradeConfig) > 0:
-			return UpgradeViaHavenerConfig(havenerUpgradeConfig)
-
+		case len(args) == 1:
+			return UpgradeViaHavenerConfig(args[0])
 		default:
 			cmd.Usage()
 		}
+
 		return nil
 	},
 }
@@ -62,12 +59,10 @@ var upgradeCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(upgradeCmd)
 
-	upgradeCmd.PersistentFlags().String("config", "", "havener configuration file")
 	upgradeCmd.PersistentFlags().Int("timeout", 40, "upgrade timeout in minutes")
 	upgradeCmd.PersistentFlags().Bool("reuse-values", false, "reuse the last release's values and merge in any overrides")
 
 	viper.AutomaticEnv()
-	viper.BindPFlag(envVarUpgradeConfig, upgradeCmd.PersistentFlags().Lookup("config"))
 	viper.BindPFlag(envVarUpgradeTimeout, upgradeCmd.PersistentFlags().Lookup("timeout"))
 	viper.BindPFlag(envVarUpgradeValueReuse, upgradeCmd.PersistentFlags().Lookup("reuse-values"))
 }

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -33,6 +33,7 @@ import (
 )
 
 const (
+	envVarUpgradeConfig     = "upgrade_config"
 	envVarUpgradeTimeout    = "upgrade_timeout"
 	envVarUpgradeValueReuse = "upgrade_reuse_values"
 )
@@ -45,9 +46,13 @@ var upgradeCmd = &cobra.Command{
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		havenerConfig := viper.GetString(envVarUpgradeConfig)
+
 		switch {
 		case len(args) == 1:
 			return UpgradeViaHavenerConfig(args[0])
+		case len(havenerConfig) > 0:
+			return UpgradeViaHavenerConfig(havenerConfig)
 		default:
 			cmd.Usage()
 		}
@@ -59,10 +64,12 @@ var upgradeCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(upgradeCmd)
 
+	upgradeCmd.PersistentFlags().String("config", "", "havener configuration file")
 	upgradeCmd.PersistentFlags().Int("timeout", 40, "upgrade timeout in minutes")
 	upgradeCmd.PersistentFlags().Bool("reuse-values", false, "reuse the last release's values and merge in any overrides")
 
 	viper.AutomaticEnv()
+	viper.BindPFlag(envVarUpgradeConfig, upgradeCmd.PersistentFlags().Lookup("config"))
 	viper.BindPFlag(envVarUpgradeTimeout, upgradeCmd.PersistentFlags().Lookup("timeout"))
 	viper.BindPFlag(envVarUpgradeValueReuse, upgradeCmd.PersistentFlags().Lookup("reuse-values"))
 }


### PR DESCRIPTION
* Replace '--config' flag with argument
* Add downwards-compability for '--config' flag

Fix #169 