### PR TITLE
Add processing of release section and refactor deploy/upgrade

### DIFF
--- a/examples/mongodb-config.yml
+++ b/examples/mongodb-config.yml
@@ -1,8 +1,8 @@
 name: mongo deployment
 releases:
 - name: mongodb
-  namespace: mongodb
-  version: (( env VERSION ))
+  namespace: (( env CFNAMESPACE ))
+  version: 1
   location: stable/mongodb
   overrides:
     mongodbUsername: (( env USERNAME ))
@@ -12,7 +12,7 @@ releases:
   after: [echo "Installed mongoDB instance with credentials $USERNAME/$PASSWORD"]
 
 env:
-  VERSION: 1
+  CFNAMESPACE: databases
   USERNAME: (( shell echo "user" ))
   PASSWORD: (( env USERNAME ))-12345678
   DATABASE: admin

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -191,15 +191,10 @@ func printStatusMessage(head string, body string, headColor colorful.Color) {
 	bunt.Println()
 }
 
-// processOverrideSection rewrites the override section of the havener config
-// by resolving its operators.
-func processOverrideSection(release havener.Release) ([]byte, error) {
-	overrides, err := havener.TraverseStructureAndProcessOperators(release.Overrides)
-	if err != nil {
-		return nil, wrap.Error(err, "failed to process overrides section")
-	}
-
-	overridesData, err := yaml.Marshal(overrides)
+// marshallOverrideSection marshalls the override section of the havener config
+// for using it in helm deployment.
+func marshallOverrideSection(release havener.Release) ([]byte, error) {
+	overridesData, err := yaml.Marshal(release.Overrides)
 	if err != nil {
 		return nil, wrap.Error(err, "failed to marshal overrides structure into bytes")
 	}

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -75,12 +75,7 @@ func init() {
 func DeployViaHavenerConfig(havenerConfig string) error {
 	timeoutInMin := viper.GetInt(envVarDeployTimeout)
 
-	config, err := havener.ParseConfigFile(havenerConfig)
-	if err != nil {
-		return err
-	}
-
-	err = havener.SetConfigEnv(config)
+	config, err := havener.ProcessConfigFile(havenerConfig)
 	if err != nil {
 		return err
 	}
@@ -90,7 +85,7 @@ func DeployViaHavenerConfig(havenerConfig string) error {
 	}
 
 	for _, release := range config.Releases {
-		overridesData, err := processOverrideSection(release)
+		overridesData, err := marshallOverrideSection(release)
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -79,12 +79,7 @@ func UpgradeViaHavenerConfig(havenerConfig string) error {
 	timeoutInMin := viper.GetInt(envVarUpgradeTimeout)
 	reuseValues := viper.GetBool(envVarUpgradeValueReuse)
 
-	config, err := havener.ParseConfigFile(havenerConfig)
-	if err != nil {
-		return err
-	}
-
-	err = havener.SetConfigEnv(config)
+	config, err := havener.ProcessConfigFile(havenerConfig)
 	if err != nil {
 		return err
 	}
@@ -94,7 +89,7 @@ func UpgradeViaHavenerConfig(havenerConfig string) error {
 	}
 
 	for _, release := range config.Releases {
-		overridesData, err := processOverrideSection(release)
+		overridesData, err := marshallOverrideSection(release)
 		if err != nil {
 			return err
 		}

--- a/pkg/havener/exec.go
+++ b/pkg/havener/exec.go
@@ -47,10 +47,26 @@ func ProcessConfigFile(path string) (*Config, error) {
 	}
 
 	for idx, release := range config.Releases {
+		config.Releases[idx].ChartName, err = ProcessOperators(release.ChartName)
+		if err != nil {
+			return nil, err
+		}
+		config.Releases[idx].ChartVersion, err = ProcessOperators(release.ChartVersion)
+		if err != nil {
+			return nil, err
+		}
+		config.Releases[idx].ChartNamespace, err = ProcessOperators(release.ChartNamespace)
+		if err != nil {
+			return nil, err
+		}
+		config.Releases[idx].ChartLocation, err = ProcessOperators(release.ChartLocation)
+		if err != nil {
+			return nil, err
+		}
+
 		if release.Overrides == nil {
 			continue
 		}
-
 		config.Releases[idx].Overrides, err = TraverseStructureAndProcessOperators(release.Overrides)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This commit includes the keys of the general release section (name, namespace...)
into the pre-processing (operators) and refactors the entire processing in deploy
and upgrade commands to remove duplicated code.

Fix #173 