### PR TITLE
Rework purge command

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,6 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/homeport/dyff v0.10.2 h1:RbjcX69NklnmiyFrmqZ7xyay/gYuTdIpJb38641zyUM=
-github.com/homeport/dyff v0.10.2/go.mod h1:SIkQzgBoS28oXext60M9fQ6HXu1UVju400Usm9iHFoc=
 github.com/homeport/dyff v0.10.3 h1:QwGY4gzCZt/VDAsXne6ogIYDe0WH3ekY4kq+NdHGIg8=
 github.com/homeport/dyff v0.10.3/go.mod h1:6c68ioNWYw2mNbECgkekrBDS0k6U5WpIe6vEtX+qzIE=
 github.com/homeport/ytbx v1.1.2 h1:iSoBNw/ij3haCY63uUMNIrwarvdbyArfmrvY/bOcbZ4=

--- a/internal/cmd/common.go
+++ b/internal/cmd/common.go
@@ -45,7 +45,7 @@ func PromptUser(message string) bool {
 		return true
 	}
 
-	fmt.Println(message)
+	fmt.Print(message)
 
 	scanner := bufio.NewScanner(os.Stdin)
 	if scanner.Scan() {

--- a/pkg/havener/common.go
+++ b/pkg/havener/common.go
@@ -136,3 +136,12 @@ func getSecretValue(namespace string, secretName string, secretKey string) (stri
 
 	return string(secretValue), nil
 }
+
+func isSystemNamespace(namespace string) bool {
+	switch namespace {
+	case "default", "kube-system", "ibm-system":
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
Do not print new line after confirmation question.

Skip system namespaces in purge routines, for example namespace `default`.

Improve readability in purge progress indicator by using highlights and more
spaces to separate the Helm Release names.

Add list of Helm Releases in the error output, so that the end user does not
have to enter `helm list` first.