### PR TITLE
Add special node exec target called "all"

### DIFF
--- a/pkg/havener/kubexec.go
+++ b/pkg/havener/kubexec.go
@@ -89,7 +89,7 @@ func PodExec(client kubernetes.Interface, restconfig *rest.Config, pod *corev1.P
 }
 
 // NodeExec executes the provided command on the given node.
-func NodeExec(client kubernetes.Interface, restconfig *rest.Config, node *corev1.Node, containerImage string, timeoutSeconds int, command []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, tty bool) error {
+func NodeExec(client kubernetes.Interface, restconfig *rest.Config, node corev1.Node, containerImage string, timeoutSeconds int, command []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, tty bool) error {
 	logf(Verbose, "Executing command on node: %#v", command)
 
 	namespace := "kube-system"


### PR DESCRIPTION
One of the common use cases for node-exec is to run a command on all
nodes of a cluster at the same time. For that, one has to first get a
list of all nodes and then specify them in the command line. Introducing
a special target called `all` delegates this task to `havener`.

Introduce special case in node lookup code to return a list of all nodes
in the cluster if the target is called `all`.

Change type of node list from pointer to the actual struct to have a
common style and less code. Remove usage of a pointer rather than the
node itself in the main node exec function code, too.

Rework the help and usage texts to reflect the special target changes.