### PR TITLE
Add load average in top output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/viper v1.4.0
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1

--- a/internal/cmd/cmd_suite_test.go
+++ b/internal/cmd/cmd_suite_test.go
@@ -25,9 +25,26 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/gonvenience/bunt"
+	"github.com/gonvenience/term"
 )
 
 func TestCmd(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Havener Command Package Suite")
 }
+
+var _ = BeforeSuite(func() {
+	bunt.ColorSetting = bunt.OFF
+	bunt.TrueColorSetting = bunt.OFF
+	term.FixedTerminalWidth = 120
+	term.FixedTerminalHeight = 40
+})
+
+var _ = AfterSuite(func() {
+	bunt.ColorSetting = bunt.AUTO
+	bunt.TrueColorSetting = bunt.AUTO
+	term.FixedTerminalWidth = -1
+	term.FixedTerminalHeight = -1
+})

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -63,7 +63,7 @@ func init() {
 }
 
 func retrieveClusterLogs() error {
-	clientSet, restconfig, err := havener.OutOfClusterAuthentication("")
+	hvnr, err := havener.NewHavener()
 	if err != nil {
 		return wrap.Error(err, "unable to get access to cluster")
 	}
@@ -85,9 +85,7 @@ func retrieveClusterLogs() error {
 
 	resultChan := make(chan error, 1)
 	go func() {
-		resultChan <- havener.RetrieveLogs(
-			clientSet,
-			restconfig,
+		resultChan <- hvnr.RetrieveLogs(
 			parallelDownloads,
 			downloadLocation,
 			!excludeConfigFiles,

--- a/internal/cmd/top_test.go
+++ b/internal/cmd/top_test.go
@@ -1,0 +1,61 @@
+// Copyright © 2019 The Havener
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/homeport/havener/internal/cmd"
+	. "github.com/homeport/havener/pkg/havener"
+
+	"github.com/gonvenience/term"
+)
+
+var _ = Describe("usage details string rendering", func() {
+	Context("render node details", func() {
+		It("should render the node details in a somehow pleasant and readable form", func() {
+			Expect(term.GetTerminalWidth()).To(BeEquivalentTo(120))
+			Expect(RenderNodeDetails(&TopDetails{
+				Nodes: map[string]NodeDetails{
+					"node1": {
+						TotalCPU:    4000,
+						TotalMemory: 16384000,
+						UsedCPU:     2000,
+						UsedMemory:  8192000,
+						LoadAvg:     []float64{4.0, 2.0, 1.0},
+					},
+					"node2": {
+						TotalCPU:    4000,
+						TotalMemory: 16384000,
+						UsedCPU:     4000,
+						UsedMemory:  16384000,
+						LoadAvg:     []float64{10.0, 10.0, 10.0},
+					},
+				},
+			})).To(BeEquivalentTo(`╭ CPU and Memory usage by Node
+│ node2  Load 10.0 10.0 10.0  CPU ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 100.0%  Memory ■■■■■■■■■■■■■■■■■■■ 15.6 MiB/15.6 MiB
+│ node1  Load 4.0 2.0 1.0     CPU ■■■■■■■■■■■■■■■■■                  50.0%  Memory ■■■■■■■■■■           7.8 MiB/15.6 MiB
+╵
+`))
+		})
+	})
+})

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -35,6 +35,7 @@ import (
 )
 
 var watchCmdSettings struct {
+	interval   int
 	namespaces []string
 }
 
@@ -57,7 +58,7 @@ var watchCmd = &cobra.Command{
 			return err
 		}
 
-		var ticker = time.NewTicker(time.Duration(interval) * time.Second)
+		var ticker = time.NewTicker(time.Duration(watchCmdSettings.interval) * time.Second)
 		for {
 			select {
 			case <-ticker.C:
@@ -72,6 +73,7 @@ var watchCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(watchCmd)
 
+	watchCmd.PersistentFlags().IntVarP(&watchCmdSettings.interval, "interval", "i", 2, "interval between measurements in seconds")
 	watchCmd.PersistentFlags().StringSliceVarP(&watchCmdSettings.namespaces, "namespace", "n", []string{}, "comma separated list of namespaces to filter (default is to use all namespaces")
 }
 

--- a/pkg/havener/havener.go
+++ b/pkg/havener/havener.go
@@ -30,6 +30,8 @@ this kind of workload.
 package havener
 
 import (
+	"io"
+
 	"github.com/gonvenience/wrap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -67,9 +69,16 @@ type Hvnr struct {
 // Havener is an interface to work with a cluster through the havener
 // abstraction layer
 type Havener interface {
+	Client() kubernetes.Interface
+	RESTConfig() *rest.Config
+	ClusterName() string
+
 	TopDetails() (*TopDetails, error)
 	ListPods(namespaces ...string) ([]*corev1.Pod, error)
-	ClusterName() string
+	RetrieveLogs(parallelDownloads int, target string, includeConfigFiles bool) error
+
+	PodExec(pod *corev1.Pod, container string, command []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, tty bool) error
+	NodeExec(node corev1.Node, containerImage string, timeoutSeconds int, command []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, tty bool) error
 }
 
 // NewHavener returns a new Havener handle to perform cluster actions
@@ -94,4 +103,14 @@ func NewHavener() (*Hvnr, error) {
 // ClusterName returns the name of the currently configured cluster
 func (h *Hvnr) ClusterName() string {
 	return h.clusterName
+}
+
+// Client returns the Kubernetes interface client for the configured cluster
+func (h *Hvnr) Client() kubernetes.Interface {
+	return h.client
+}
+
+// RESTConfig returns the REST config handle for the configured cluster
+func (h *Hvnr) RESTConfig() *rest.Config {
+	return h.restconfig
 }

--- a/pkg/havener/list.go
+++ b/pkg/havener/list.go
@@ -23,6 +23,8 @@ package havener
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gonvenience/wrap"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -128,10 +130,36 @@ func (h *Hvnr) ListPods(namespaces ...string) (result []*corev1.Pod, err error) 
 }
 
 // ListNodes lists all nodes of the cluster
+// Deprecated: Use Havener interface function ListNodeNames instead
 func ListNodes(client kubernetes.Interface) ([]string, error) {
 	nodeList, err := client.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
+	}
+
+	result := make([]string, len(nodeList.Items))
+	for i, node := range nodeList.Items {
+		result[i] = node.Name
+	}
+
+	return result, nil
+}
+
+// ListNodes returns a list of the nodes in the cluster
+func (h *Hvnr) ListNodes() ([]corev1.Node, error) {
+	nodeList, err := h.client.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, wrap.Error(err, "failed to get list of nodes")
+	}
+
+	return nodeList.Items, nil
+}
+
+// ListNodeNames returns a list of the names of the nodes in the cluster
+func (h *Hvnr) ListNodeNames() ([]string, error) {
+	nodeList, err := h.client.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return nil, wrap.Error(err, "failed to get list of nodes")
 	}
 
 	result := make([]string, len(nodeList.Items))

--- a/pkg/havener/top.go
+++ b/pkg/havener/top.go
@@ -25,10 +25,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gonvenience/wrap"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gonvenience/wrap"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // NodeDetails consists of the used and total values for CPU and Memory
@@ -148,11 +149,12 @@ func (h *Hvnr) TopDetails() (*TopDetails, error) {
 
 	var (
 		wg      sync.WaitGroup
-		errChan = make(chan error, 2)
+		errChan = make(chan error)
 	)
 
 	wg.Add(2)
 
+	// Reach out to Kubernetes metrics service to get node details
 	go func() {
 		defer wg.Done()
 
@@ -176,6 +178,7 @@ func (h *Hvnr) TopDetails() (*TopDetails, error) {
 		}
 	}()
 
+	// Reach out to Kubernetes metrics service to get pod details
 	go func() {
 		defer wg.Done()
 


### PR DESCRIPTION
The CPU and Memory usage is not enough to decide whether a system is performing
well or not. Another useful indicator is the load average of the node.

Add usage retriever pod that runs in the background as long as `top` runs. Get
load average values using this pod as part of the details gathering.

Insert a load average display in the node usage box.

Introduce test case to check the rendering of the node usage box.