### PR TITLE
watch: Add support for different resources

### DIFF
--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -53,6 +53,10 @@ var watchCmd = &cobra.Command{
 			return err
 		}
 
+		if watchCmdSettings.crd != "" && watchCmdSettings.resource != "" {
+			return errors.New("--resource and --crd flags cannot be specified simultaneously")
+		}
+
 		term.HideCursor()
 		defer term.ShowCursor()
 
@@ -83,10 +87,6 @@ func init() {
 
 func printWatchList(hvnr havener.Havener) (err error) {
 	var out string
-
-	if watchCmdSettings.crd != "" && watchCmdSettings.resource != "" {
-		return errors.New("--resource and --crd flags cannot be specified simultaneously")
-	}
 
 	if watchCmdSettings.crd != "" {
 		out, err = generateCRDTable(hvnr)
@@ -295,7 +295,7 @@ func generateCRDTable(hvnr havener.Havener) (string, error) {
 	var (
 		tableSec = [][]string{}
 	)
-	bdplList, err := hvnr.ListCRDItems(watchCmdSettings.crd)
+	bdplList, err := hvnr.ListCustomResourceDefinition(watchCmdSettings.crd)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/havener/havener.go
+++ b/pkg/havener/havener.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gonvenience/wrap"
 	"golang.org/x/sync/syncmap"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
@@ -86,6 +87,9 @@ type Havener interface {
 
 	PodExec(pod *corev1.Pod, container string, command []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, tty bool) error
 	NodeExec(node corev1.Node, containerImage string, timeoutSeconds int, command []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, tty bool) error
+	ListSecrets(namespaces ...string) ([]*corev1.Secret, error)
+	ListConfigMaps(namespaces ...string) ([]*corev1.ConfigMap, error)
+	ListCRDItems(string) ([]unstructured.Unstructured, error)
 }
 
 // NewHavener returns a new Havener handle to perform cluster actions

--- a/pkg/havener/havener.go
+++ b/pkg/havener/havener.go
@@ -89,7 +89,7 @@ type Havener interface {
 	NodeExec(node corev1.Node, containerImage string, timeoutSeconds int, command []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, tty bool) error
 	ListSecrets(namespaces ...string) ([]*corev1.Secret, error)
 	ListConfigMaps(namespaces ...string) ([]*corev1.ConfigMap, error)
-	ListCRDItems(string) ([]unstructured.Unstructured, error)
+	ListCustomResourceDefinition(string) ([]unstructured.Unstructured, error)
 }
 
 // NewHavener returns a new Havener handle to perform cluster actions

--- a/pkg/havener/list.go
+++ b/pkg/havener/list.go
@@ -21,10 +21,15 @@
 package havener
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gonvenience/wrap"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -127,6 +132,79 @@ func (h *Hvnr) ListPods(namespaces ...string) (result []*corev1.Pod, err error) 
 	}
 
 	return result, nil
+}
+
+// ListSecrets lists all secrets in the given namespaces, if no namespace is given,
+// then all namespaces currently available in the cluster will be used
+func (h *Hvnr) ListSecrets(namespaces ...string) (result []*corev1.Secret, err error) {
+	if len(namespaces) == 0 {
+		namespaces, err = ListNamespaces(h.client)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, namespace := range namespaces {
+		listResp, err := h.client.CoreV1().Secrets(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range listResp.Items {
+			result = append(result, &listResp.Items[i])
+		}
+	}
+
+	return result, nil
+}
+
+// ListConfigMaps lists all confimaps in the given namespaces, if no namespace is given,
+// then all namespaces currently available in the cluster will be used
+func (h *Hvnr) ListConfigMaps(namespaces ...string) (result []*corev1.ConfigMap, err error) {
+	if len(namespaces) == 0 {
+		namespaces, err = ListNamespaces(h.client)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, namespace := range namespaces {
+		listResp, err := h.client.CoreV1().ConfigMaps(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+
+		for i := range listResp.Items {
+			result = append(result, &listResp.Items[i])
+		}
+	}
+
+	return result, nil
+}
+
+// ListCRDItems lists all instances of an specific CRD
+func (h *Hvnr) ListCRDItems(crdName string) (result []unstructured.Unstructured, err error) {
+
+	var runtimeClassGVR schema.GroupVersionResource
+
+	apiResourceList, err := h.client.Discovery().ServerResources()
+	if err != nil {
+		return nil, err
+	}
+
+	crdExist, runtimeClassGVR := apiCRDResourceExist(apiResourceList, crdName)
+
+	if crdExist {
+		client, _ := dynamic.NewForConfig(h.restconfig)
+		list, _ := client.Resource(runtimeClassGVR).List(metav1.ListOptions{})
+
+		for i := range list.Items {
+			result = append(result, list.Items[i])
+		}
+		return result, nil
+	}
+
+	return result, fmt.Errorf("desired resource %s, was not found", crdName)
 }
 
 // ListNodes lists all nodes of the cluster

--- a/pkg/havener/list.go
+++ b/pkg/havener/list.go
@@ -182,8 +182,8 @@ func (h *Hvnr) ListConfigMaps(namespaces ...string) (result []*corev1.ConfigMap,
 	return result, nil
 }
 
-// ListCRDItems lists all instances of an specific CRD
-func (h *Hvnr) ListCRDItems(crdName string) (result []unstructured.Unstructured, err error) {
+// ListCustomResourceDefinition lists all instances of an specific CRD
+func (h *Hvnr) ListCustomResourceDefinition(crdName string) (result []unstructured.Unstructured, err error) {
 
 	var runtimeClassGVR schema.GroupVersionResource
 


### PR DESCRIPTION
This includes:
- secrets
- configmaps
- CRDs

For the subcmd, this includes two new flags:
- `-r` for specifying the resource
- `-c` for specifying the CRD

For the `-r` flag:
- Default behaviour will be to watch `pods`

For the `-c` flag:
- User can specify the short name or the singular name
of the resource.