### PR TITLE
Fix load display issue

### DIFF
--- a/internal/cmd/top.go
+++ b/internal/cmd/top.go
@@ -405,9 +405,10 @@ func sortedNodeList(topDetails *havener.TopDetails) []string {
 }
 
 func fill(text string, length int) string {
+	var textLength = bunt.PlainTextLength(text)
 	switch {
-	case len(text) < length:
-		return text + strings.Repeat(" ", length-len(text))
+	case textLength < length:
+		return text + strings.Repeat(" ", length-textLength)
 
 	default:
 		return text


### PR DESCRIPTION
The output for the load average does not calculate the text length correctly,
because it is counting escape sequences as text.

Use `bunt` package to determine the text length.