### PR TITLE
Fix top hang in case of pod scheduling issues

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,7 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -264,6 +265,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-charset v0.0.0-20180617210344-2471d30d28b4/go.mod h1:qgYeAmZ5ZIpBWTGllZSQnw97Dj+woV0toclVaRGI8pc=
+github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/internal/cmd/top.go
+++ b/internal/cmd/top.go
@@ -513,7 +513,7 @@ func renderProgressBar(value int64, max int64, caption string, text string, leng
 				buf.WriteString(
 					bunt.Style(
 						symbol,
-						bunt.Foreground(bunt.DimGray),
+						bunt.Foreground(bunt.DimGray.BlendLab(bunt.Black, 0.5)),
 					),
 				)
 

--- a/internal/cmd/top.go
+++ b/internal/cmd/top.go
@@ -531,6 +531,10 @@ func renderProgressBar(value int64, max int64, caption string, text string, leng
 }
 
 func renderLoadAvg(caption string, stats havener.NodeDetails) string {
+	if len(stats.LoadAvg) == 0 {
+		return bunt.Sprintf("*%s* DimGray{_(no data)_}", caption)
+	}
+
 	colorForLoad := func(value float64, max float64) colorful.Color {
 		switch {
 		case value > max:

--- a/internal/cmd/top_test.go
+++ b/internal/cmd/top_test.go
@@ -57,5 +57,31 @@ var _ = Describe("usage details string rendering", func() {
 ╵
 `))
 		})
+
+		It("should render the node details even if not all details are available", func() {
+			Expect(term.GetTerminalWidth()).To(BeEquivalentTo(120))
+			Expect(RenderNodeDetails(&TopDetails{
+				Nodes: map[string]NodeDetails{
+					"node1": {
+						TotalCPU:    4000,
+						TotalMemory: 16384000,
+						UsedCPU:     2000,
+						UsedMemory:  8192000,
+						LoadAvg:     nil,
+					},
+					"node2": {
+						TotalCPU:    4000,
+						TotalMemory: 16384000,
+						UsedCPU:     4000,
+						UsedMemory:  16384000,
+						LoadAvg:     []float64{10.0, 10.0, 10.0},
+					},
+				},
+			})).To(BeEquivalentTo(`╭ CPU and Memory usage by Node
+│ node2  Load 10.0 10.0 10.0  CPU ■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 100.0%  Memory ■■■■■■■■■■■■■■■■■■■ 15.6 MiB/15.6 MiB
+│ node1  Load (no data)       CPU ■■■■■■■■■■■■■■■■■                  50.0%  Memory ■■■■■■■■■■           7.8 MiB/15.6 MiB
+╵
+`))
+		})
 	})
 })

--- a/pkg/havener/top.go
+++ b/pkg/havener/top.go
@@ -223,8 +223,12 @@ func (h *Hvnr) TopDetails() (*TopDetails, error) {
 			if err != nil {
 				pod, err = h.preparePodOnNode(node, "kube-system", podname, "alpine", 5, true)
 				if err != nil {
-					errChan <- err
+					return
 				}
+			}
+
+			if pod.Status.Phase == corev1.PodPending {
+				return
 			}
 
 			var stdout bytes.Buffer


### PR DESCRIPTION
In case a node is cordoned, but the load on the node does not allow for a pod
placement, the top command just hangs failing to get data.

Introduce two ways that the additional data retriever Go routine exits without
gathering data so that the overall process does not hang itself.

Add special case to node details rendering so that missing data is correctly
displayed as data unavailable.