### PR TITLE
Add node and location to watch command

### DIFF
--- a/pkg/havener/havener.go
+++ b/pkg/havener/havener.go
@@ -83,6 +83,7 @@ type Havener interface {
 
 	TopDetails() (*TopDetails, error)
 	ListPods(namespaces ...string) ([]*corev1.Pod, error)
+	ListNodes() ([]corev1.Node, error)
 	RetrieveLogs(parallelDownloads int, target string, includeConfigFiles bool) error
 
 	PodExec(pod *corev1.Pod, container string, command []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, tty bool) error


### PR DESCRIPTION
It is often also useful to see on which node a pod is located.

Add two more columns to the watch output: node and location. The
location is currently using an IBM Cloud specific label.

Switch to row limiting code from the `neat` package.