### PR TITLE
Check input from /proc/loadavg

### DIFF
--- a/pkg/havener/top.go
+++ b/pkg/havener/top.go
@@ -280,6 +280,10 @@ func parseQuantity(input string) *resource.Quantity {
 
 func parseProcLoadAvg(input string) []float64 {
 	parts := strings.Split(input, " ")
+	if len(parts) != 5 {
+		return []float64{}
+	}
+
 	l1, _ := strconv.ParseFloat(parts[0], 64)
 	l5, _ := strconv.ParseFloat(parts[1], 64)
 	l15, _ := strconv.ParseFloat(parts[2], 64)


### PR DESCRIPTION
There are use cases, where the input from `/proc/loadavg` does not
contain the expected five values and therefore a panic occurrs, since
there is no sanity check in place.

Add basic check the the input string indeed contains five parts.

Should fix #204.