### PR TITLE
Improvements pod exec

### DIFF
--- a/internal/cmd/nexec.go
+++ b/internal/cmd/nexec.go
@@ -177,10 +177,10 @@ func execInClusterNodes(args []string) error {
 	// Start the respective output printer in a separate Go routine
 	go func() {
 		if nodeExecBlock {
-			PrintOutputMessageAsBlock(output, len(nodes))
+			PrintOutputMessageAsBlock(output)
 
 		} else {
-			PrintOutputMessage(output, len(nodes))
+			PrintOutputMessage(output)
 		}
 
 		printer <- true

--- a/internal/cmd/output_print.go
+++ b/internal/cmd/output_print.go
@@ -60,17 +60,19 @@ func chanWriter(stream string, origin string, c chan OutputMsg) io.Writer {
 
 // PrintOutputMessage reads from the given output message channel and prints the
 // respective messages without any buffering or sorting.
-func PrintOutputMessage(messages chan OutputMsg, items int) error {
+func PrintOutputMessage(messages chan OutputMsg) error {
 	var (
-		colors        = bunt.RandomTerminalFriendlyColors(items)
-		originCounter = 0
-		originColors  = map[string]colorful.Color{}
+		numberOfColors = 64
+		colors         = bunt.RandomTerminalFriendlyColors(numberOfColors)
+		originCounter  = 0
+		originColors   = map[string]colorful.Color{}
 	)
 
 	for msg := range messages {
 		if _, ok := originColors[msg.Origin]; !ok {
 			originColors[msg.Origin] = colors[originCounter]
-			originCounter++
+
+			originCounter = (originCounter + 1) % numberOfColors
 		}
 
 		printMessage(originColors[msg.Origin], msg)
@@ -82,11 +84,12 @@ func PrintOutputMessage(messages chan OutputMsg, items int) error {
 // PrintOutputMessageAsBlock reads from the given output message channel and
 // buffers the input until the channel is closed. Once closed, it prints the
 // output messages sorted by the origin.
-func PrintOutputMessageAsBlock(messages chan OutputMsg, items int) {
+func PrintOutputMessageAsBlock(messages chan OutputMsg) {
 	var (
-		colors = bunt.RandomTerminalFriendlyColors(items)
-		data   = map[string][]OutputMsg{}
-		keys   = []string{}
+		numberOfColors = 64
+		colors         = bunt.RandomTerminalFriendlyColors(numberOfColors)
+		data           = map[string][]OutputMsg{}
+		keys           = []string{}
 	)
 
 	// Fully read the input channel and store the output messages indexed by the
@@ -109,7 +112,7 @@ func PrintOutputMessageAsBlock(messages chan OutputMsg, items int) {
 		for _, msg := range data[key] {
 			printMessage(colors[i], msg)
 		}
-		i++
+		i = (i + 1) % numberOfColors
 	}
 }
 

--- a/internal/cmd/output_print_test.go
+++ b/internal/cmd/output_print_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Output message printing", func() {
 		}()
 
 		actual := captureStdout(func() {
-			PrintOutputMessage(exampleChannel, 2)
+			PrintOutputMessage(exampleChannel)
 		})
 
 		expected := "08:20:16 Prefix1 │ bin    etc    lib    mnt    proc   run    srv    tmp    var\n" +
@@ -140,7 +140,7 @@ var _ = Describe("Output message printing", func() {
 		}()
 
 		actual := captureStdout(func() {
-			PrintOutputMessageAsBlock(exampleChannel, 2)
+			PrintOutputMessageAsBlock(exampleChannel)
 		})
 
 		expected := "08:20:16 Prefix1 │ bin    etc    lib    mnt    proc   run    srv    tmp    var\n" +

--- a/internal/cmd/pexec.go
+++ b/internal/cmd/pexec.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gonvenience/wrap"
 	"github.com/homeport/havener/pkg/havener"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -80,7 +81,7 @@ all pods in all namespaces automatically.
 
 func init() {
 	rootCmd.AddCommand(podExecCmd)
-
+	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
 	podExecCmd.PersistentFlags().BoolVar(&podExecNoTty, "no-tty", false, "do not allocate pseudo-terminal for command execution")
 	podExecCmd.PersistentFlags().BoolVar(&podExecBlock, "block", false, "show distributed shell output as block for each pod")
 }
@@ -92,9 +93,10 @@ func execInClusterPods(args []string) error {
 	}
 
 	var (
-		podMap  map[*corev1.Pod]string
-		input   string
-		command []string
+		podMap          map[*corev1.Pod][]string
+		countContainers int
+		input           string
+		command         []string
 	)
 
 	switch {
@@ -116,6 +118,14 @@ func execInClusterPods(args []string) error {
 		return availablePodsError(hvnr.Client(), "no pod name specified")
 	}
 
+	// Count number of containers from all pods
+	// We only get all containers per pod, when "all" is specified
+	for _, containers := range podMap {
+		for range containers {
+			countContainers++
+		}
+	}
+
 	// In case the current process does not run in a terminal, disable the
 	// default TTY behavior.
 	if !term.IsTerminal() {
@@ -124,16 +134,19 @@ func execInClusterPods(args []string) error {
 
 	// Single pod mode, use default streams and run pod execute function
 	if len(podMap) == 1 {
-		for pod, container := range podMap {
-			return hvnr.PodExec(
-				pod,
-				container,
-				command,
-				os.Stdin,
-				os.Stdout,
-				os.Stderr,
-				!podExecNoTty,
-			)
+		for pod, containers := range podMap {
+			for i := range containers {
+				return hvnr.PodExec(
+					pod,
+					containers[i],
+					command,
+					os.Stdin,
+					os.Stdout,
+					os.Stderr,
+					!podExecNoTty,
+				)
+			}
+
 		}
 	}
 
@@ -142,42 +155,40 @@ func execInClusterPods(args []string) error {
 
 	var (
 		wg      = &sync.WaitGroup{}
-		readers = duplicateReader(os.Stdin, len(podMap))
+		readers = duplicateReader(os.Stdin, countContainers)
 		output  = make(chan OutputMsg)
-		errors  = make(chan error, len(podMap))
+		errors  = make(chan error, countContainers)
 		printer = make(chan bool, 1)
 		counter = 0
 	)
-
-	wg.Add(len(podMap))
-	for pod, container := range podMap {
-		go func(pod *corev1.Pod, container string, reader io.Reader) {
-			defer func() {
-				wg.Done()
-			}()
-
-			origin := fmt.Sprintf("%s/%s", pod.Name, container)
-			errors <- hvnr.PodExec(
-				pod,
-				container,
-				command,
-				reader,
-				chanWriter("StdOut", origin, output),
-				chanWriter("StdErr", origin, output),
-				!podExecNoTty,
-			)
-		}(pod, container, readers[counter])
-
-		counter++
+	// wg.Add(countContainers)
+	for pod, containers := range podMap {
+		for i := range containers {
+			wg.Add(1)
+			go func(pod *corev1.Pod, container string, reader io.Reader) {
+				defer wg.Done()
+				origin := fmt.Sprintf("%s/%s", pod.Name, container)
+				errors <- hvnr.PodExec(
+					pod,
+					container,
+					command,
+					reader,
+					chanWriter("StdOut", origin, output),
+					chanWriter("StdErr", origin, output),
+					!podExecNoTty,
+				)
+			}(pod, containers[i], readers[counter])
+			counter++
+		}
 	}
 
 	// Start the respective output printer in a separate Go routine
 	go func() {
 		if podExecBlock {
-			PrintOutputMessageAsBlock(output, len(podMap))
+			PrintOutputMessageAsBlock(output)
 
 		} else {
-			PrintOutputMessage(output, len(podMap))
+			PrintOutputMessage(output)
 		}
 
 		printer <- true
@@ -187,18 +198,27 @@ func execInClusterPods(args []string) error {
 	close(errors)
 	close(output)
 
-	if err := combineErrorsFromChannel("pod command execution failed", errors); err != nil {
-		return err
+	if viper.GetBool("verbose") {
+		if err := combineErrorsFromChannel("pod command execution failed", errors); err != nil {
+			return err
+		}
 	}
 
 	<-printer
 	return nil
 }
 
-func lookupAllPods(client kubernetes.Interface, namespaces []string) (map[*corev1.Pod]string, error) {
+func lookupPodContainers(client kubernetes.Interface, p *corev1.Pod) (containerList []string, err error) {
+	for _, c := range p.Spec.Containers {
+		containerList = append(containerList, c.Name)
+	}
+	return containerList, err
+}
 
-	var podLists map[*corev1.Pod]string
-	podLists = make(map[*corev1.Pod]string)
+func lookupAllPods(client kubernetes.Interface, namespaces []string) (map[*corev1.Pod][]string, error) {
+
+	var podLists map[*corev1.Pod][]string
+	podLists = make(map[*corev1.Pod][]string)
 	for _, namespace := range namespaces {
 		podsPerNs, err := client.CoreV1().Pods(namespace).List(metav1.ListOptions{})
 		if err != nil {
@@ -206,16 +226,20 @@ func lookupAllPods(client kubernetes.Interface, namespaces []string) (map[*corev
 		}
 
 		for i := range podsPerNs.Items {
-			podLists[&(podsPerNs.Items[i])] = podsPerNs.Items[i].Spec.Containers[0].Name
+			listOfContainers, err := lookupPodContainers(client, &(podsPerNs.Items[i]))
+			if err != nil {
+				return nil, err
+			}
+			podLists[&(podsPerNs.Items[i])] = listOfContainers
 		}
 	}
 	return podLists, nil
 }
 
-func lookupPodsByName(client kubernetes.Interface, input string) (map[*corev1.Pod]string, error) {
+func lookupPodsByName(client kubernetes.Interface, input string) (map[*corev1.Pod][]string, error) {
 	inputList := strings.Split(input, ",")
 
-	podList := make(map[*corev1.Pod]string, len(inputList))
+	podList := make(map[*corev1.Pod][]string, len(inputList))
 	for _, podName := range inputList {
 		splited := strings.Split(podName, "/")
 
@@ -245,7 +269,7 @@ func lookupPodsByName(client kubernetes.Interface, input string) (map[*corev1.Po
 				return nil, fmt.Errorf("more than one pod named %s found, please specify a namespace", input)
 			}
 
-			podList[pods[0]] = pods[0].Spec.Containers[0].Name
+			podList[pods[0]] = []string{pods[0].Spec.Containers[0].Name}
 
 		case 2: // namespace, and pod name is given
 			namespace, podName := splited[0], splited[1]
@@ -254,7 +278,7 @@ func lookupPodsByName(client kubernetes.Interface, input string) (map[*corev1.Po
 				return nil, availablePodsError(client, fmt.Sprintf("pod %s not found", input))
 			}
 
-			podList[pod] = pod.Spec.Containers[0].Name
+			podList[pod] = []string{pod.Spec.Containers[0].Name}
 
 		case 3: // namespace, pod, and container name is given
 			namespace, podName, container := splited[0], splited[1], splited[2]
@@ -263,7 +287,7 @@ func lookupPodsByName(client kubernetes.Interface, input string) (map[*corev1.Po
 				return nil, availablePodsError(client, fmt.Sprintf("pod %s not found", input))
 			}
 
-			podList[pod] = container
+			podList[pod] = []string{container}
 
 		default:
 			return nil, fmt.Errorf("unsupported naming schema, it needs to be [namespace/]pod[/container]")

--- a/pkg/havener/kubexec.go
+++ b/pkg/havener/kubexec.go
@@ -76,7 +76,7 @@ func (h *Hvnr) PodExec(pod *corev1.Pod, container string, command []string, stdi
 	}
 
 	if err = executor.Stream(remotecommand.StreamOptions{Stdin: stdin, Stdout: stdout, Stderr: stderr, Tty: tty, TerminalSizeQueue: tsq}); err != nil {
-		return wrap.Errorf(err, "failed to exectue command on pod %s, container %s", pod.Name, container)
+		return wrap.Errorf(err, "failed to execute command on pod %s, container %s", pod.Name, container)
 	}
 
 	logf(Verbose, "Successfully executed command.")


### PR DESCRIPTION
Allow user to specify "all", so that the command will be executed in all pods/containers.

Also, do not show errors of those containers that are not reachable, and allow them to be seen only via the `verbose` flag.