### PR TITLE
Improve error message of node-exec timeout

### DIFF
--- a/pkg/havener/havener.go
+++ b/pkg/havener/havener.go
@@ -38,8 +38,11 @@ import (
 	"golang.org/x/sync/syncmap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/describe"
+	"k8s.io/kubectl/pkg/describe/versioned"
 )
 
 // Helpful imports:
@@ -150,4 +153,19 @@ func (h *Hvnr) Client() kubernetes.Interface {
 // RESTConfig returns the REST config handle for the configured cluster
 func (h *Hvnr) RESTConfig() *rest.Config {
 	return h.restconfig
+}
+
+func (h *Hvnr) describePod(pod *corev1.Pod) (string, error) {
+	describer, ok := versioned.DescriberFor(schema.GroupKind{Group: corev1.GroupName, Kind: "Pod"}, h.restconfig)
+	if !ok {
+		return "", fmt.Errorf("failed to setup up describer for pods")
+	}
+
+	return describer.Describe(
+		pod.Namespace,
+		pod.Name,
+		describe.DescriberSettings{
+			ShowEvents: true,
+		},
+	)
 }

--- a/pkg/havener/kubexec.go
+++ b/pkg/havener/kubexec.go
@@ -192,7 +192,17 @@ func (h *Hvnr) waitForPodReadiness(namespace string, pod *corev1.Pod, timeoutSec
 			return err
 
 		case <-timeout:
-			return fmt.Errorf("failed to get pod after %d seconds", timeoutSeconds)
+			description, err := h.describePod(pod)
+			if err != nil {
+				description = "Unable to provide further details regarding the state of the pod."
+			}
+
+			return wrap.Errorf(fmt.Errorf("Status of pod at the moment of the timeout:\n\n%s", description),
+				"Giving up waiting for pod %s in namespace %s to become ready within %s",
+				pod.Name,
+				pod.Namespace,
+				text.Plural(timeoutSeconds, "second"),
+			)
 		}
 	}
 }


### PR DESCRIPTION
When the `node-exec` command fails to get a pod ready in time, it fails
with an error message that does not give too much details on why the pod
could not come up.

Add more details to the error message using the already existing pod
describe logic used by the `logs` command.

Instead of: 
![image](https://user-images.githubusercontent.com/1979133/74142732-c9096f00-4bf9-11ea-85b1-0441faabf79d.png)

It is more like: 
![image](https://user-images.githubusercontent.com/1979133/74142772-da527b80-4bf9-11ea-9de2-98b8b1af8b42.png)

