### PR TITLE
Fix `KUBECONFIG` default behaviour

### DIFF
--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -54,7 +54,12 @@ The download includes all deployment YAMLs of the pods and the describe output.`
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return retrieveClusterLogs()
+		hvnr, err := havener.NewHavener(havener.KubeConfig(kubeConfig))
+		if err != nil {
+			return wrap.Error(err, "unable to get access to cluster")
+		}
+
+		return retrieveClusterLogs(hvnr)
 	},
 }
 
@@ -67,12 +72,7 @@ func init() {
 	logsCmd.PersistentFlags().IntVar(&parallelDownloads, "parallel", 64, "number of parallel download jobs")
 }
 
-func retrieveClusterLogs() error {
-	hvnr, err := havener.NewHavener()
-	if err != nil {
-		return wrap.Error(err, "unable to get access to cluster")
-	}
-
+func retrieveClusterLogs(hvnr havener.Havener) error {
 	var commonText string
 	if excludeConfigFiles {
 		commonText = "log files"

--- a/internal/cmd/nexec.go
+++ b/internal/cmd/nexec.go
@@ -81,7 +81,12 @@ all nodes automatically.
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return execInClusterNodes(args)
+		hvnr, err := havener.NewHavener(havener.KubeConfig(kubeConfig))
+		if err != nil {
+			return wrap.Error(err, "unable to get access to cluster")
+		}
+
+		return execInClusterNodes(hvnr, args)
 	},
 }
 
@@ -95,16 +100,12 @@ func init() {
 	nodeExecCmd.PersistentFlags().IntVar(&nodeExecMaxParallel, "max-parallel", 0, "number of parallel executions (defaults to number of nodes)")
 }
 
-func execInClusterNodes(args []string) error {
-	hvnr, err := havener.NewHavener()
-	if err != nil {
-		return wrap.Error(err, "unable to get access to cluster")
-	}
-
+func execInClusterNodes(hvnr havener.Havener, args []string) error {
 	var (
 		nodes   []corev1.Node
 		input   string
 		command []string
+		err     error
 	)
 
 	switch {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -25,10 +25,10 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path/filepath"
 	"runtime/debug"
 	"strings"
 
+	"github.com/homeport/havener/pkg/havener"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
@@ -37,6 +37,8 @@ import (
 	"github.com/gonvenience/term"
 	"github.com/gonvenience/wrap"
 )
+
+var kubeConfig string
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -96,15 +98,16 @@ func Execute() {
 }
 
 func init() {
-	home, err := os.UserHomeDir()
+	kubeConfigDefault, err := havener.KubeConfigDefault()
 	if err != nil {
-		panic(wrap.Error(err, "unable to get home directory"))
+		panic(err)
 	}
 
 	rootCmd.Flags().SortFlags = false
 	rootCmd.PersistentFlags().SortFlags = false
 
-	rootCmd.PersistentFlags().String("kubeconfig", filepath.Join(home, ".kube", "config"), "Kubernetes configuration file")
+	rootCmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", kubeConfigDefault, "Kubernetes configuration file")
+
 	rootCmd.PersistentFlags().Int("terminal-width", -1, "disable autodetection and specify an explicit terminal width")
 	rootCmd.PersistentFlags().Int("terminal-height", -1, "disable autodetection and specify an explicit terminal height")
 
@@ -116,7 +119,6 @@ func init() {
 	rootCmd.PersistentFlags().Bool("trace", false, "trace output - level 6")
 
 	// Bind environment variables to CLI flags
-	viper.BindPFlag("kubeconfig", rootCmd.PersistentFlags().Lookup("kubeconfig"))
 	viper.BindPFlag("TERMINAL_WIDTH", rootCmd.PersistentFlags().Lookup("terminal-width"))
 	viper.BindPFlag("TERMINAL_HEIGHT", rootCmd.PersistentFlags().Lookup("terminal-height"))
 

--- a/internal/cmd/top.go
+++ b/internal/cmd/top.go
@@ -70,7 +70,7 @@ cluster as well as a list per node.
 			topCmdSettings.cycles = 1
 		}
 
-		hvnr, err := havener.NewHavener()
+		hvnr, err := havener.NewHavener(havener.KubeConfig(kubeConfig))
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -48,7 +48,7 @@ var watchCmd = &cobra.Command{
 	Short: "Watch status of all pods in all namespaces",
 	Long:  `Continuesly creates a list of all pods in all namespaces.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		hvnr, err := havener.NewHavener()
+		hvnr, err := havener.NewHavener(havener.KubeConfig(kubeConfig))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
So far, the `havener` CLI did not behave the same way as `kubectl`, when it
comes to the Kubernetes configuration usage. If the `KUBECONFIG` environment
variable is set, this should always take precedence over the command line flag
or the default system location for the Kubernetes configuration.

Unify usage of `havener.NewHavener` function call.

Introduce options to `NewHavener` function to be able to override settings.

Add check for `KUBECONFIG` environment variable.
