### PR TITLE
Add Google Cloud Platform auth import

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ cloud.google.com/go v0.72.0/go.mod h1:M+5Vjvlc2wnp6tjzE102Dw08nGShTscUx2nZMufOKP
 cloud.google.com/go v0.74.0/go.mod h1:VV1xSbzvo+9QJOxLDaJfTjx5e+MePCpCWwvftOeQmWk=
 cloud.google.com/go v0.78.0/go.mod h1:QjdrLG0uq+YwhjoVOLsS1t7TW8fs36kLs4XO5R5ECHg=
 cloud.google.com/go v0.79.0/go.mod h1:3bzgcEeQlzbuEAYu4mrWhKqWjmpprinYgKJLgKHnbb8=
+cloud.google.com/go v0.81.0 h1:at8Tk2zUz63cLPR0JPWm5vp77pEZmzxEQBEfRKn1VV8=
 cloud.google.com/go v0.81.0/go.mod h1:mk/AM35KwGk/Nm2YSeZbxXdrNK3KZOYHmLkOqC2V6E0=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=

--- a/pkg/havener/common.go
+++ b/pkg/havener/common.go
@@ -27,15 +27,20 @@ import (
 	"path/filepath"
 	"strings"
 
-	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc" //from https://github.com/kubernetes/client-go/issues/345
+	// https://github.com/kubernetes/client-go/issues/345
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
-	"github.com/gonvenience/wrap"
-	"gopkg.in/yaml.v3"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	// https://github.com/homeport/havener/issues/420
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/gonvenience/wrap"
+	"gopkg.in/yaml.v3"
 )
 
 // KubeConfigDefault returns assumed default locaation of the Kubernetes
@@ -98,7 +103,7 @@ func clusterName(kubeConfig string) (string, error) {
 	return "", fmt.Errorf("unable to determine cluster name based on Kubernetes configuration")
 }
 
-func apiCRDResourceExist(arl []*v1.APIResourceList, crdName string) (bool, schema.GroupVersionResource) {
+func apiCRDResourceExist(arl []*meta.APIResourceList, crdName string) (bool, schema.GroupVersionResource) {
 	for _, ar := range arl {
 		// Look for a CRD based on it´s singular or
 		// different short names.


### PR DESCRIPTION
Fixes #420

Include `k8s.io/client-go/plugin/pkg/client/auth/gcp` import.
