### PR TITLE
Fix linter warnings

### DIFF
--- a/internal/cmd/events.go
+++ b/internal/cmd/events.go
@@ -86,12 +86,12 @@ func retrieveClusterEvents(hvnr havener.Havener) error {
 			continue
 		}
 
-		go func() error {
-			watcher, err := hvnr.Client().CoreV1().Events(namespace).Watch(context.TODO(), metav1.ListOptions{})
-			if err != nil {
-				return wrap.Error(err, "failed to setup event watcher")
-			}
+		watcher, err := hvnr.Client().CoreV1().Events(namespace).Watch(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return wrap.Error(err, "failed to setup event watcher")
+		}
 
+		go func() {
 			for event := range watcher.ResultChan() {
 				switch event.Type {
 				case watch.Added, watch.Modified:
@@ -116,7 +116,6 @@ func retrieveClusterEvents(hvnr havener.Havener) error {
 					}
 				}
 			}
-			return nil
 		}()
 	}
 

--- a/internal/cmd/output_print.go
+++ b/internal/cmd/output_print.go
@@ -60,7 +60,7 @@ func chanWriter(stream string, origin string, c chan OutputMsg) io.Writer {
 
 // PrintOutputMessage reads from the given output message channel and prints the
 // respective messages without any buffering or sorting.
-func PrintOutputMessage(messages chan OutputMsg) error {
+func PrintOutputMessage(messages chan OutputMsg) {
 	var (
 		numberOfColors = 64
 		colors         = bunt.RandomTerminalFriendlyColors(numberOfColors)
@@ -77,8 +77,6 @@ func PrintOutputMessage(messages chan OutputMsg) error {
 
 		printMessage(originColors[msg.Origin], msg)
 	}
-
-	return nil
 }
 
 // PrintOutputMessageAsBlock reads from the given output message channel and

--- a/internal/cmd/pexec.go
+++ b/internal/cmd/pexec.go
@@ -75,7 +75,7 @@ all pods in all namespaces automatically.
 `,
 	SilenceUsage:  true,
 	SilenceErrors: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, args []string) error {
 		hvnr, err := havener.NewHavener(havener.KubeConfig(kubeConfig))
 		if err != nil {
 			return wrap.Error(err, "unable to get access to cluster")
@@ -87,9 +87,9 @@ all pods in all namespaces automatically.
 
 func init() {
 	rootCmd.AddCommand(podExecCmd)
-	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
-	podExecCmd.PersistentFlags().BoolVar(&podExecNoTty, "no-tty", false, "do not allocate pseudo-terminal for command execution")
-	podExecCmd.PersistentFlags().BoolVar(&podExecBlock, "block", false, "show distributed shell output as block for each pod")
+
+	podExecCmd.Flags().BoolVar(&podExecNoTty, "no-tty", false, "do not allocate pseudo-terminal for command execution")
+	podExecCmd.Flags().BoolVar(&podExecBlock, "block", false, "show distributed shell output as block for each pod")
 }
 
 func execInClusterPods(hvnr havener.Havener, args []string) error {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -119,15 +119,15 @@ func init() {
 	rootCmd.PersistentFlags().Bool("trace", false, "trace output - level 6")
 
 	// Bind environment variables to CLI flags
-	viper.BindPFlag("TERMINAL_WIDTH", rootCmd.PersistentFlags().Lookup("terminal-width"))
-	viper.BindPFlag("TERMINAL_HEIGHT", rootCmd.PersistentFlags().Lookup("terminal-height"))
+	_ = viper.BindPFlag("TERMINAL_WIDTH", rootCmd.PersistentFlags().Lookup("terminal-width"))
+	_ = viper.BindPFlag("TERMINAL_HEIGHT", rootCmd.PersistentFlags().Lookup("terminal-height"))
 
-	viper.BindPFlag("fatal", rootCmd.PersistentFlags().Lookup("fatal"))
-	viper.BindPFlag("error", rootCmd.PersistentFlags().Lookup("error"))
-	viper.BindPFlag("warn", rootCmd.PersistentFlags().Lookup("warn"))
-	viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
-	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
-	viper.BindPFlag("trace", rootCmd.PersistentFlags().Lookup("trace"))
+	_ = viper.BindPFlag("fatal", rootCmd.PersistentFlags().Lookup("fatal"))
+	_ = viper.BindPFlag("error", rootCmd.PersistentFlags().Lookup("error"))
+	_ = viper.BindPFlag("warn", rootCmd.PersistentFlags().Lookup("warn"))
+	_ = viper.BindPFlag("verbose", rootCmd.PersistentFlags().Lookup("verbose"))
+	_ = viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
+	_ = viper.BindPFlag("trace", rootCmd.PersistentFlags().Lookup("trace"))
 
 	term.FixedTerminalWidth, term.FixedTerminalHeight = viper.GetInt("TERMINAL_WIDTH"), viper.GetInt("TERMINAL_HEIGHT")
 


### PR DESCRIPTION
Remove unused return types.

Ignore errors that are not required to be checked.
