### PR TITLE
Introduce glob logic for pod-exec

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,19 +24,6 @@ jobs:
       with:
         go-version: 1.22.x
 
-    - name: Setup Go build cache
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Build source code
-      run: go build ./...
-
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v6
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,13 +35,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - name: Build
-      run: go build ./...
-
     - name: Test
-      run: |
-        go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
-        make test
+      run: make test
 
     - name: Upload Code Coverage Profile
       uses: codecov/codecov-action@v4

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ all: test
 .PHONY: clean
 clean:
 	@rm -rf dist
-	@go clean -cache $(shell go list ./...)
+	@go clean -i -cache
 
 .PHONY: todo-list
 todo-list:

--- a/Makefile
+++ b/Makefile
@@ -39,14 +39,14 @@ lint:
 
 .PHONY: misspell
 misspell:
-	@find . -type f \( -name "*.go" -o -name "*.md" \) -print0 | xargs -0 misspell -error
+	@find . -type f -not -path "./vendor/*" \( -name "*.go" -o -name "*.md" \) -print0 | xargs -0 misspell -error
 
 .PHONY: unit-test
 unit-test: test
 
 .PHONY: test
 test:
-	@ginkgo run \
+	@go run -mod=mod github.com/onsi/ginkgo/v2/ginkgo run \
 	  --coverprofile=unit.coverprofile \
 	  --randomize-all \
 	  --randomize-suites \

--- a/internal/cmd/events.go
+++ b/internal/cmd/events.go
@@ -71,7 +71,7 @@ func init() {
 }
 
 func retrieveClusterEvents(hvnr havener.Havener) error {
-	namespaces, err := havener.ListNamespaces(hvnr.Client())
+	namespaces, err := hvnr.ListNamespaces()
 	if err != nil {
 		return fmt.Errorf("failed to get a list of namespaces: %w", err)
 	}

--- a/internal/cmd/events.go
+++ b/internal/cmd/events.go
@@ -95,10 +95,8 @@ func retrieveClusterEvents(hvnr havener.Havener) error {
 			for event := range watcher.ResultChan() {
 				switch event.Type {
 				case watch.Added, watch.Modified:
-					switch event.Object.(type) {
+					switch data := event.Object.(type) {
 					case *corev1.Event:
-						data := *(event.Object.(*corev1.Event))
-
 						resourceName := data.Name
 						if strings.Contains(resourceName, ".") {
 							parts := strings.Split(resourceName, ".")

--- a/internal/cmd/pexec.go
+++ b/internal/cmd/pexec.go
@@ -162,7 +162,7 @@ func execInClusterPods(hvnr havener.Havener, args []string) error {
 		printer = make(chan bool, 1)
 		counter = 0
 	)
-	// wg.Add(countContainers)
+
 	for pod, containers := range podMap {
 		for i := range containers {
 			wg.Add(1)

--- a/internal/cmd/top.go
+++ b/internal/cmd/top.go
@@ -486,7 +486,7 @@ func renderProgressBar(value int64, max int64, caption string, text string, leng
 	const symbol = "■"
 
 	if !strings.HasSuffix(caption, " ") {
-		caption = caption + " "
+		caption += " "
 	}
 
 	if !strings.HasPrefix(text, " ") {

--- a/internal/cmd/watch.go
+++ b/internal/cmd/watch.go
@@ -389,15 +389,15 @@ func humanReadableDuration(duration time.Duration) string {
 
 	if seconds >= 60 {
 		minutes = seconds / 60
-		seconds = seconds % 60
+		seconds %= 60
 
 		if minutes >= 60 {
 			hours = minutes / 60
-			minutes = minutes % 60
+			minutes %= 60
 
 			if hours >= 24 {
 				days = hours / 24
-				hours = hours % 24
+				hours %= 24
 			}
 		}
 	}

--- a/pkg/havener/havener.go
+++ b/pkg/havener/havener.go
@@ -139,7 +139,7 @@ func NewHavener(opts ...Option) (hvnr *Hvnr, err error) {
 		opt(hvnr)
 	}
 
-	// Set default backgroud context if nothing is set
+	// Set default background context if nothing is set
 	if hvnr.ctx == nil {
 		hvnr.ctx = context.Background()
 	}

--- a/pkg/havener/kubexec.go
+++ b/pkg/havener/kubexec.go
@@ -81,7 +81,6 @@ func (h *Hvnr) PodExec(pod *corev1.Pod, container string, command []string, stdi
 	}
 
 	logf(Verbose, "Successfully executed command.")
-
 	return nil
 }
 

--- a/pkg/havener/kubexec.go
+++ b/pkg/havener/kubexec.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -40,7 +41,7 @@ import (
 
 // PodExec executes the provided command in the referenced pod's container.
 func (h *Hvnr) PodExec(pod *corev1.Pod, container string, command []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, tty bool) error {
-	logf(Verbose, "Executing command on pod: %#v", command)
+	logf(Verbose, "Executing command on pod: `%v`", strings.Join(command, " "))
 
 	req := h.client.CoreV1().RESTClient().Post().
 		Resource("pods").


### PR DESCRIPTION
Allow usage of a glob when specifying the target for a `pod-exec`, e.g. `havener pod-exec "istiod-*" -- /bin/sh -c "commands"`, which will search all namespaces for pods that glob match the provided name.

0fbe5154 Simplify GitHub Action setup
53f5098b Fix `go clean` in Make target
73489bfa Run Ginkgo from source in Make target
1bcb59e3 Fix `gocritic` findings
a2c7168a Remove unnecessary comment
47891d2d Fix TYPO in comment
38506def Improve command run verbose output
60cad27a Introduce glob logic for pod-exec
