### PR TITLE
Refactor `havener` pkg

### DIFF
--- a/internal/cmd/nexec.go
+++ b/internal/cmd/nexec.go
@@ -21,7 +21,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -35,7 +34,6 @@ import (
 	"github.com/gonvenience/term"
 	"github.com/homeport/havener/pkg/havener"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
 )
 
 const nodeDefaultCommand = "/bin/sh"
@@ -110,20 +108,20 @@ func execInClusterNodes(hvnr havener.Havener, args []string) error {
 	switch {
 	case len(args) >= 2: // node name and command is given
 		input, command = args[0], args[1:]
-		nodes, err = lookupNodesByName(hvnr.Client(), input)
+		nodes, err = lookupNodesByName(hvnr, input)
 		if err != nil {
 			return err
 		}
 
 	case len(args) == 1: // only node name is given
 		input, command = args[0], []string{nodeDefaultCommand}
-		nodes, err = lookupNodesByName(hvnr.Client(), input)
+		nodes, err = lookupNodesByName(hvnr, input)
 		if err != nil {
 			return err
 		}
 
 	default: // no arguments
-		return availableNodesError(hvnr.Client(), "no node name and command specified")
+		return availableNodesError(hvnr, "no node name and command specified")
 	}
 
 	// In case the current process does not run in a terminal, disable the
@@ -214,9 +212,9 @@ func execInClusterNodes(hvnr havener.Havener, args []string) error {
 	return combineErrorsFromChannel("node command execution failed", errors)
 }
 
-func lookupNodesByName(client kubernetes.Interface, input string) ([]corev1.Node, error) {
+func lookupNodesByName(h havener.Havener, input string) ([]corev1.Node, error) {
 	if input == "all" {
-		list, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+		list, err := h.Client().CoreV1().Nodes().List(h.Context(), metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -226,9 +224,9 @@ func lookupNodesByName(client kubernetes.Interface, input string) ([]corev1.Node
 
 	var nodeList []corev1.Node
 	for _, nodeName := range strings.Split(input, ",") {
-		node, err := client.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})
+		node, err := h.Client().CoreV1().Nodes().Get(h.Context(), nodeName, metav1.GetOptions{})
 		if err != nil {
-			return nil, availableNodesError(client, "node '%s' does not exist", nodeName)
+			return nil, availableNodesError(h, "node '%s' does not exist", nodeName)
 		}
 
 		nodeList = append(nodeList, *node)
@@ -237,8 +235,8 @@ func lookupNodesByName(client kubernetes.Interface, input string) ([]corev1.Node
 	return nodeList, nil
 }
 
-func availableNodesError(client kubernetes.Interface, title string, fArgs ...interface{}) error {
-	nodes, err := havener.ListNodes(client)
+func availableNodesError(h havener.Havener, title string, fArgs ...interface{}) error {
+	nodes, err := h.ListNodes()
 	if err != nil {
 		return fmt.Errorf("failed to list all nodes in cluster: %w", err)
 	}
@@ -247,8 +245,13 @@ func availableNodesError(client kubernetes.Interface, title string, fArgs ...int
 		return fmt.Errorf("failed to find any node in cluster")
 	}
 
+	names := make([]string, len(nodes))
+	for i, node := range nodes {
+		names[i] = node.Name
+	}
+
 	return fmt.Errorf("%s: %w",
 		fmt.Sprintf(title, fArgs...),
-		bunt.Errorf("*list of available nodes:*\n%s\n\nor, use _all_ to target all nodes", strings.Join(nodes, "\n")),
+		bunt.Errorf("*list of available nodes:*\n%s\n\nor, use _all_ to target all nodes", strings.Join(names, "\n")),
 	)
 }

--- a/internal/cmd/nexec.go
+++ b/internal/cmd/nexec.go
@@ -214,12 +214,7 @@ func execInClusterNodes(hvnr havener.Havener, args []string) error {
 
 func lookupNodesByName(h havener.Havener, input string) ([]corev1.Node, error) {
 	if input == "all" {
-		list, err := h.Client().CoreV1().Nodes().List(h.Context(), metav1.ListOptions{})
-		if err != nil {
-			return nil, err
-		}
-
-		return list.Items, nil
+		return h.ListNodes()
 	}
 
 	var nodeList []corev1.Node

--- a/pkg/havener/common.go
+++ b/pkg/havener/common.go
@@ -58,7 +58,12 @@ func outOfClusterAuthentication(kubeConfig string) (*kubernetes.Clientset, *rest
 		return nil, nil, fmt.Errorf("no kube config supplied")
 	}
 
-	logf(Verbose, "Connecting to Kubernetes cluster...")
+	clusterName, err := clusterName(kubeConfig)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to look-up cluster name: %w", err)
+	}
+
+	logf(Verbose, "Connecting to Kubernetes cluster _%s_ ...", clusterName)
 
 	// BuildConfigFromFlags is a helper function that builds configs from a master
 	// url or a kubeconfig filepath.

--- a/pkg/havener/kubexec.go
+++ b/pkg/havener/kubexec.go
@@ -93,7 +93,7 @@ func (h *Hvnr) NodeExec(node corev1.Node, containerImage string, timeoutSeconds 
 	)
 
 	// Make sure to stop pod after command execution
-	defer func() { _ = PurgePod(h.client, namespace, podName, 10, metav1.DeletePropagationForeground) }()
+	defer func() { _ = h.PurgePod(namespace, podName, 10, metav1.DeletePropagationForeground) }()
 
 	pod, err := h.preparePodOnNode(node, namespace, podName, containerImage, timeoutSeconds, stdin != nil)
 	if err != nil {
@@ -115,7 +115,7 @@ func (h *Hvnr) NodeExec(node corev1.Node, containerImage string, timeoutSeconds 
 
 func (h *Hvnr) preparePodOnNode(node corev1.Node, namespace string, name string, containerImage string, timeoutSeconds int, useStdin bool) (*corev1.Pod, error) {
 	// Add pod deletion to shutdown sequence list (in case of Ctrl+C exit)
-	AddShutdownFunction(func() { _ = PurgePod(h.client, namespace, name, 10, metav1.DeletePropagationBackground) })
+	AddShutdownFunction(func() { _ = h.PurgePod(namespace, name, 10, metav1.DeletePropagationBackground) })
 
 	// Pod configuration
 	pod := &corev1.Pod{

--- a/pkg/havener/kubexec.go
+++ b/pkg/havener/kubexec.go
@@ -101,7 +101,7 @@ func (h *Hvnr) NodeExec(node corev1.Node, containerImage string, timeoutSeconds 
 	}
 
 	// Execute command on pod and redirect output to users provided stdout and stderr
-	logf(Verbose, "Executing command on node: %#v", command)
+	logf(Verbose, "Executing command on node: `%v`", strings.Join(command, " "))
 	return h.PodExec(
 		pod,
 		"node-exec-container",
@@ -124,9 +124,14 @@ func (h *Hvnr) preparePodOnNode(node corev1.Node, namespace string, name string,
 			Namespace: namespace,
 		},
 		Spec: corev1.PodSpec{
-			NodeSelector:  map[string]string{"kubernetes.io/hostname": node.Name}, // Deploy pod on specific node using label selector
-			HostPID:       true,
-			RestartPolicy: corev1.RestartPolicyNever,
+			NodeSelector: map[string]string{
+				// Deploy pod on specific node using label selector
+				corev1.LabelHostname: node.Name,
+			},
+			HostPID:                       true,
+			HostNetwork:                   true,
+			RestartPolicy:                 corev1.RestartPolicyNever,
+			TerminationGracePeriodSeconds: pointer.Int64(0),
 			Containers: []corev1.Container{
 				{
 					Name:            "node-exec-container",

--- a/pkg/havener/list.go
+++ b/pkg/havener/list.go
@@ -21,7 +21,6 @@
 package havener
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -32,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/gonvenience/text"
 )
@@ -193,22 +191,6 @@ func (h *Hvnr) ListCustomResourceDefinition(crdName string) (result []unstructur
 	}
 
 	return nil, fmt.Errorf("desired resource %s, was not found", crdName)
-}
-
-// ListNodes lists all nodes of the cluster
-// Deprecated: Use Havener interface function ListNodeNames instead
-func ListNodes(client kubernetes.Interface) ([]string, error) {
-	nodeList, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	result := make([]string, len(nodeList.Items))
-	for i, node := range nodeList.Items {
-		result[i] = node.Name
-	}
-
-	return result, nil
 }
 
 // ListNodes returns a list of the nodes in the cluster

--- a/pkg/havener/list.go
+++ b/pkg/havener/list.go
@@ -138,7 +138,7 @@ func (h *Hvnr) ListSecrets(namespaces ...string) (result []*corev1.Secret, err e
 	}
 
 	for _, namespace := range namespaces {
-		listResp, err := h.client.CoreV1().Secrets(namespace).List(context.TODO(), metav1.ListOptions{})
+		listResp, err := h.client.CoreV1().Secrets(namespace).List(h.ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -162,7 +162,7 @@ func (h *Hvnr) ListConfigMaps(namespaces ...string) (result []*corev1.ConfigMap,
 	}
 
 	for _, namespace := range namespaces {
-		listResp, err := h.client.CoreV1().ConfigMaps(namespace).List(context.TODO(), metav1.ListOptions{})
+		listResp, err := h.client.CoreV1().ConfigMaps(namespace).List(h.ctx, metav1.ListOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -188,7 +188,7 @@ func (h *Hvnr) ListCustomResourceDefinition(crdName string) (result []unstructur
 
 	if crdExist {
 		client, _ := dynamic.NewForConfig(h.restconfig)
-		list, _ := client.Resource(runtimeClassGVR).List(context.TODO(), metav1.ListOptions{})
+		list, _ := client.Resource(runtimeClassGVR).List(h.ctx, metav1.ListOptions{})
 		return list.Items, nil
 	}
 
@@ -213,7 +213,7 @@ func ListNodes(client kubernetes.Interface) ([]string, error) {
 
 // ListNodes returns a list of the nodes in the cluster
 func (h *Hvnr) ListNodes() ([]corev1.Node, error) {
-	nodeList, err := h.client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	nodeList, err := h.client.CoreV1().Nodes().List(h.ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get list of nodes: %w", err)
 	}
@@ -223,7 +223,7 @@ func (h *Hvnr) ListNodes() ([]corev1.Node, error) {
 
 // ListNodeNames returns a list of the names of the nodes in the cluster
 func (h *Hvnr) ListNodeNames() ([]string, error) {
-	nodeList, err := h.client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
+	nodeList, err := h.client.CoreV1().Nodes().List(h.ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get list of nodes: %w", err)
 	}

--- a/pkg/havener/purge.go
+++ b/pkg/havener/purge.go
@@ -21,18 +21,13 @@
 package havener
 
 import (
-	"context"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"k8s.io/client-go/kubernetes"
 )
 
 // PurgePod removes the pod in the given namespace.
-func PurgePod(kubeClient kubernetes.Interface, namespace string, podName string, gracePeriodSeconds int64, propagationPolicy metav1.DeletionPropagation) error {
+func (h *Hvnr) PurgePod(namespace string, podName string, gracePeriodSeconds int64, propagationPolicy metav1.DeletionPropagation) error {
 	logf(Verbose, "Deleting pod %s in namespace %s", podName, namespace)
-	return kubeClient.CoreV1().Pods(namespace).Delete(
-		context.TODO(),
+	return h.client.CoreV1().Pods(namespace).Delete(h.ctx,
 		podName,
 		metav1.DeleteOptions{
 			GracePeriodSeconds: &gracePeriodSeconds,


### PR DESCRIPTION
- Refactor `PurgePod` to pointer receiver
- Use handle context in calls
- Refactor `node-exec` to use program context
- Include cluster name in verbose output
- Simplify code by reusing existing list function
- Tweak node exec setup
