### PR TITLE
Rework `pod-exec` and `node-exec`

### DIFF
--- a/.docs/commands/havener.md
+++ b/.docs/commands/havener.md
@@ -17,7 +17,7 @@ See the individual commands to get the complete overview.
 ### Options
 
 ```
-      --kubeconfig string     Kubernetes configuration file (default "~/.kube/config")
+      --kubeconfig string     Kubernetes configuration (default "~/.kube/config")
       --terminal-width int    disable autodetection and specify an explicit terminal width (default -1)
       --terminal-height int   disable autodetection and specify an explicit terminal height (default -1)
       --fatal                 fatal output - level 1

--- a/.docs/commands/havener_events.md
+++ b/.docs/commands/havener_events.md
@@ -23,7 +23,7 @@ havener events [flags]
       --debug                 debug output - level 5
       --error                 error output - level 2
       --fatal                 fatal output - level 1
-      --kubeconfig string     Kubernetes configuration file (default "~/.kube/config")
+      --kubeconfig string     Kubernetes configuration (default "~/.kube/config")
       --terminal-height int   disable autodetection and specify an explicit terminal height (default -1)
       --terminal-width int    disable autodetection and specify an explicit terminal width (default -1)
       --trace                 trace output - level 6

--- a/.docs/commands/havener_logs.md
+++ b/.docs/commands/havener_logs.md
@@ -31,7 +31,7 @@ havener logs [flags]
       --debug                 debug output - level 5
       --error                 error output - level 2
       --fatal                 fatal output - level 1
-      --kubeconfig string     Kubernetes configuration file (default "~/.kube/config")
+      --kubeconfig string     Kubernetes configuration (default "~/.kube/config")
       --terminal-height int   disable autodetection and specify an explicit terminal height (default -1)
       --terminal-width int    disable autodetection and specify an explicit terminal width (default -1)
       --trace                 trace output - level 6

--- a/.docs/commands/havener_node-exec.md
+++ b/.docs/commands/havener_node-exec.md
@@ -4,23 +4,24 @@ Execute command on Kubernetes node
 
 ### Synopsis
 
-Execute a command on a node.
+Execute a command on a node
 
-This executes a command directly on the node itself. Therefore, havener creates
-a temporary pod which enables the user to access the shell of the node. The pod
+Execute a command directly on the node itself. For this, havener creates a
+temporary pod, which enables the user to access the shell of the node. The pod
 is deleted automatically afterwards.
 
 The command can be omitted which will result in the default command: /bin/sh. For
-example 'havener node-exec foo' will search for a node named 'foo' and open a
-shell if found.
+example havener node-exec foo will search for a node named 'foo' and open a
+shell if the node can be found.
 
-Typically, the TTY flag does have to be specified. By definition, if one one
-target node is provided, it is assumed that TTY is desired and STDIN is attached
-to the remote process. Analog, for the distributed mode with multiple nodes,
-no TTY is set, and the STDIN is multiplexed into each remote process.
+When more than one node is specified, it will execute the command on all nodes.
+In this distributed mode, both passing the StdIn as well as TTY mode are not
+available. By default, the number of parallel node executions is limited to 5
+in parallel in order to not create to many requests at the same time. This
+value can be overwritten. Handle with care.
 
-If you run the 'node-exec' without any additional arguments, it will print a
-list of available nodes.
+If you run the node-exec without any additional arguments, it will print a
+list of available nodes in the cluster.
 
 For convenience, if the target node name all is used, havener will look up
 all nodes automatically.
@@ -34,12 +35,13 @@ havener node-exec [flags] [<node>[,<node>,...]] [<command>]
 ### Options
 
 ```
-      --block              show distributed shell output as block for each node
+  -i, --stdin              Pass stdin to the container
+  -t, --tty                Stdin is a TTY
+      --image string       Container image used for helper pod (from which the root-shell is accessed) (default "docker.io/library/alpine")
+      --timeout duration   Timeout for the setup of the helper pod (default 30s)
+      --max-parallel int   Number of parallel executions (value less or equal than zero means unlimited) (default 5)
+      --block              Show distributed shell output as block for each node
   -h, --help               help for node-exec
-      --image string       set image for helper pod from which the root-shell is accessed (default "alpine")
-      --max-parallel int   number of parallel executions (defaults to number of nodes)
-      --no-tty             do not allocate pseudo-terminal for command execution
-      --timeout int        set timout in seconds for the setup of the helper pod (default 10)
 ```
 
 ### Options inherited from parent commands
@@ -48,7 +50,7 @@ havener node-exec [flags] [<node>[,<node>,...]] [<command>]
       --debug                 debug output - level 5
       --error                 error output - level 2
       --fatal                 fatal output - level 1
-      --kubeconfig string     Kubernetes configuration file (default "~/.kube/config")
+      --kubeconfig string     Kubernetes configuration (default "~/.kube/config")
       --terminal-height int   disable autodetection and specify an explicit terminal height (default -1)
       --terminal-width int    disable autodetection and specify an explicit terminal width (default -1)
       --trace                 trace output - level 6

--- a/.docs/commands/havener_pod-exec.md
+++ b/.docs/commands/havener_pod-exec.md
@@ -4,26 +4,26 @@ Execute command on Kubernetes pod
 
 ### Synopsis
 
-Execute a shell command on a pod.
+Execute a command on a pod
 
-This is similar to the kubectl exec command with just a slightly
-different syntax. In contrast to kubectl, you do not have to specify
-the namespace of the pod.
+This is similar to the kubectl exec command with just a slightly different
+syntax. In contrast to kubectl, you do not have to specify the namespace
+of the pod.
 
-If no namespace is given, havener will search all namespaces for
-a pod that matches the name.
+If no namespace is given, havener will search all namespaces for a pod that
+matches the name.
 
-Also, you can omit the command which will result in the default
-command: /bin/sh. For example 'havener pod-exec api-0' will search
-for a pod named 'api-0' in all namespaces and open a shell if found.
+Also, you can omit the command which will result in the default command: /bin/sh.
+For example havener pod-exec api-0 will search for a pod named api-0 in all
+namespaces and open a shell if found.
 
-In case no container name is given, havener will assume you want to
-execute the command in the first container found in the pod.
+In case no container name is given, havener will assume you want to execute the
+command in the first container found in the pod.
 
 If you run the 'pod-exec' without any additional arguments, it will print a
 list of available pods.
 
-For convenience, if the target pod name _all_ is used, havener will look up
+For convenience, if the target pod name all is used, havener will look up
 all pods in all namespaces automatically.
 
 
@@ -34,9 +34,10 @@ havener pod-exec [flags] [[<namespace>/]<pod>[/container]] [<command>]
 ### Options
 
 ```
-      --block    show distributed shell output as block for each pod
-  -h, --help     help for pod-exec
-      --no-tty   do not allocate pseudo-terminal for command execution
+  -i, --stdin   Pass stdin to the container
+  -t, --tty     Stdin is a TTY
+      --block   show distributed shell output as block for each pod
+  -h, --help    help for pod-exec
 ```
 
 ### Options inherited from parent commands
@@ -45,7 +46,7 @@ havener pod-exec [flags] [[<namespace>/]<pod>[/container]] [<command>]
       --debug                 debug output - level 5
       --error                 error output - level 2
       --fatal                 fatal output - level 1
-      --kubeconfig string     Kubernetes configuration file (default "~/.kube/config")
+      --kubeconfig string     Kubernetes configuration (default "~/.kube/config")
       --terminal-height int   disable autodetection and specify an explicit terminal height (default -1)
       --terminal-width int    disable autodetection and specify an explicit terminal width (default -1)
       --trace                 trace output - level 6

--- a/.docs/commands/havener_top.md
+++ b/.docs/commands/havener_top.md
@@ -33,7 +33,7 @@ havener top [flags]
       --debug                 debug output - level 5
       --error                 error output - level 2
       --fatal                 fatal output - level 1
-      --kubeconfig string     Kubernetes configuration file (default "~/.kube/config")
+      --kubeconfig string     Kubernetes configuration (default "~/.kube/config")
       --terminal-height int   disable autodetection and specify an explicit terminal height (default -1)
       --terminal-width int    disable autodetection and specify an explicit terminal width (default -1)
       --trace                 trace output - level 6

--- a/.docs/commands/havener_version.md
+++ b/.docs/commands/havener_version.md
@@ -22,7 +22,7 @@ havener version [flags]
       --debug                 debug output - level 5
       --error                 error output - level 2
       --fatal                 fatal output - level 1
-      --kubeconfig string     Kubernetes configuration file (default "~/.kube/config")
+      --kubeconfig string     Kubernetes configuration (default "~/.kube/config")
       --terminal-height int   disable autodetection and specify an explicit terminal height (default -1)
       --terminal-width int    disable autodetection and specify an explicit terminal width (default -1)
       --trace                 trace output - level 6

--- a/.docs/commands/havener_watch.md
+++ b/.docs/commands/havener_watch.md
@@ -26,7 +26,7 @@ havener watch [flags]
       --debug                 debug output - level 5
       --error                 error output - level 2
       --fatal                 fatal output - level 1
-      --kubeconfig string     Kubernetes configuration file (default "~/.kube/config")
+      --kubeconfig string     Kubernetes configuration (default "~/.kube/config")
       --terminal-height int   disable autodetection and specify an explicit terminal height (default -1)
       --terminal-width int    disable autodetection and specify an explicit terminal width (default -1)
       --trace                 trace output - level 6

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gonvenience/wait v1.0.3
 	github.com/gonvenience/wrap v1.2.0
 	github.com/lucasb-eyer/go-colorful v1.2.0
+	github.com/mattn/go-isatty v0.0.18
 	github.com/onsi/ginkgo/v2 v2.17.3
 	github.com/onsi/gomega v1.33.1
 	github.com/spf13/cobra v1.8.0
@@ -58,7 +59,6 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-ciede2000 v0.0.0-20170301095244-782e8c62fec3 // indirect
-	github.com/mattn/go-isatty v0.0.18 // indirect
 	github.com/mitchellh/go-ps v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect

--- a/internal/cmd/events.go
+++ b/internal/cmd/events.go
@@ -21,7 +21,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -86,7 +85,7 @@ func retrieveClusterEvents(hvnr havener.Havener) error {
 			continue
 		}
 
-		watcher, err := hvnr.Client().CoreV1().Events(namespace).Watch(context.TODO(), metav1.ListOptions{})
+		watcher, err := hvnr.Client().CoreV1().Events(namespace).Watch(hvnr.Context(), metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to setup event watcher: %w", err)
 		}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -98,7 +98,7 @@ func Execute() {
 }
 
 func init() {
-	kubeConfigDefault, err := havener.KubeConfigDefault()
+	kubeConfigDefault, err := havener.KubeConfig()
 	if err != nil {
 		panic(err)
 	}
@@ -106,7 +106,7 @@ func init() {
 	rootCmd.Flags().SortFlags = false
 	rootCmd.PersistentFlags().SortFlags = false
 
-	rootCmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", kubeConfigDefault, "Kubernetes configuration file")
+	rootCmd.PersistentFlags().StringVar(&kubeConfig, "kubeconfig", kubeConfigDefault, "Kubernetes configuration")
 
 	rootCmd.PersistentFlags().Int("terminal-width", -1, "disable autodetection and specify an explicit terminal width")
 	rootCmd.PersistentFlags().Int("terminal-height", -1, "disable autodetection and specify an explicit terminal height")

--- a/pkg/havener/common.go
+++ b/pkg/havener/common.go
@@ -41,9 +41,16 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// KubeConfigDefault returns assumed default locaation of the Kubernetes
-// configuration, which is expected to be `$HOME/.kube/config`.
-func KubeConfigDefault() (string, error) {
+// KubeConfig returns the path to the Kubernetes configuration,
+// this is either whatever is set in KUBECONFIG,
+// or the well known default location `$HOME/.kube/config`
+func KubeConfig() (string, error) {
+	// In case `KUBECONFIG` environment variable is set, this will take precedence
+	if value, ok := os.LookupEnv("KUBECONFIG"); ok {
+		return value, nil
+	}
+
+	// Otherwise, default to the well known location
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("unable to get home directory: %w", err)

--- a/pkg/havener/kubexec.go
+++ b/pkg/havener/kubexec.go
@@ -21,7 +21,6 @@
 package havener
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -39,9 +38,28 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+type NodeExecHelperPodConfig struct {
+	namespace string
+	podName   string
+
+	Annotations    map[string]string
+	ContainerImage string
+	ContainerCmd   []string
+	ContainerArgs  []string
+	WaitTimeout    time.Duration
+}
+
+type ExecConfig struct {
+	Command []string
+	Stdin   io.Reader
+	Stdout  io.Writer
+	Stderr  io.Writer
+	TTY     bool
+}
+
 // PodExec executes the provided command in the referenced pod's container.
-func (h *Hvnr) PodExec(pod *corev1.Pod, container string, command []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, tty bool) error {
-	logf(Verbose, "Executing command on pod: `%v`", strings.Join(command, " "))
+func (h *Hvnr) PodExec(pod *corev1.Pod, container string, execConfig ExecConfig) error {
+	logf(Verbose, "Executing command on pod: `%v`", strings.Join(execConfig.Command, " "))
 
 	req := h.client.CoreV1().RESTClient().Post().
 		Resource("pods").
@@ -50,11 +68,11 @@ func (h *Hvnr) PodExec(pod *corev1.Pod, container string, command []string, stdi
 		SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
 			Container: container,
-			Command:   command,
-			Stdin:     stdin != nil,
-			Stdout:    stdout != nil,
-			Stderr:    stderr != nil,
-			TTY:       tty,
+			Command:   execConfig.Command,
+			Stdin:     execConfig.Stdin != nil,
+			Stdout:    execConfig.Stdout != nil,
+			Stderr:    execConfig.Stderr != nil,
+			TTY:       execConfig.TTY,
 		}, scheme.ParameterCodec)
 
 	executor, err := remotecommand.NewSPDYExecutor(h.restconfig, "POST", req.URL())
@@ -63,7 +81,7 @@ func (h *Hvnr) PodExec(pod *corev1.Pod, container string, command []string, stdi
 	}
 
 	var tsq *terminalSizeQueue
-	if tty && term.IsTerminal() {
+	if execConfig.TTY && term.IsTerminal() {
 		tsq = setupTerminalResizeWatcher()
 		defer tsq.stop()
 	}
@@ -71,13 +89,21 @@ func (h *Hvnr) PodExec(pod *corev1.Pod, container string, command []string, stdi
 	// Terminal needs to run in raw mode for the actual command execution when TTY is enabled.
 	// The raw mode is the one where characters are not printed twice in the terminal. See
 	// https://en.wikipedia.org/wiki/POSIX_terminal_interface#History for a bit more details.
-	if tty {
+	if execConfig.TTY {
 		if stateToBeRestored, err := terminal.MakeRaw(0); err == nil {
 			defer func() { _ = terminal.Restore(0, stateToBeRestored) }()
 		}
 	}
 
-	if err = executor.StreamWithContext(h.ctx, remotecommand.StreamOptions{Stdin: stdin, Stdout: stdout, Stderr: stderr, Tty: tty, TerminalSizeQueue: tsq}); err != nil {
+	var streamOption = remotecommand.StreamOptions{
+		Stdin:             execConfig.Stdin,
+		Stdout:            execConfig.Stdout,
+		Stderr:            execConfig.Stderr,
+		Tty:               execConfig.TTY,
+		TerminalSizeQueue: tsq,
+	}
+
+	if err = executor.StreamWithContext(h.ctx, streamOption); err != nil {
 		return fmt.Errorf("failed to execute command on pod %s, container %s: %w", pod.Name, container, err)
 	}
 
@@ -86,42 +112,47 @@ func (h *Hvnr) PodExec(pod *corev1.Pod, container string, command []string, stdi
 }
 
 // NodeExec executes the provided command on the given node.
-func (h *Hvnr) NodeExec(node corev1.Node, containerImage string, timeoutSeconds int, command []string, stdin io.Reader, stdout io.Writer, stderr io.Writer, tty bool) error {
-	var (
-		podName   = text.RandomStringWithPrefix("node-exec-", 15) // unique pod name
-		namespace = "kube-system"
-	)
+func (h *Hvnr) NodeExec(node corev1.Node, hlpPodConfig NodeExecHelperPodConfig, execConfig ExecConfig) error {
+	hlpPodConfig.podName = text.RandomStringWithPrefix("node-exec-", 15) // unique pod name
+	hlpPodConfig.namespace = "kube-system"
 
 	// Make sure to stop pod after command execution
-	defer func() { _ = h.PurgePod(namespace, podName, 10, metav1.DeletePropagationForeground) }()
+	defer func() {
+		_ = h.PurgePod(hlpPodConfig.namespace, hlpPodConfig.podName, 0, metav1.DeletePropagationBackground)
+	}()
 
-	pod, err := h.preparePodOnNode(node, namespace, podName, containerImage, timeoutSeconds, stdin != nil)
+	pod, err := h.preparePodOnNode(node, hlpPodConfig)
 	if err != nil {
 		return err
 	}
 
 	// Execute command on pod and redirect output to users provided stdout and stderr
-	logf(Verbose, "Executing command on node: `%v`", strings.Join(command, " "))
+	logf(Verbose, "Executing command on node: `%v`", strings.Join(execConfig.Command, " "))
+
 	return h.PodExec(
-		pod,
-		"node-exec-container",
-		append([]string{"nsenter", "--target", "1", "--mount", "--uts", "--ipc", "--net", "--pid", "--"}, command...),
-		stdin,
-		stdout,
-		stderr,
-		tty,
+		pod, "node-exec-container",
+		ExecConfig{
+			Command: append([]string{"nsenter", "--target", "1", "--mount", "--uts", "--ipc", "--net", "--pid", "--"}, execConfig.Command...),
+			Stdin:   execConfig.Stdin,
+			Stdout:  execConfig.Stdout,
+			Stderr:  execConfig.Stderr,
+			TTY:     execConfig.TTY,
+		},
 	)
 }
 
-func (h *Hvnr) preparePodOnNode(node corev1.Node, namespace string, name string, containerImage string, timeoutSeconds int, useStdin bool) (*corev1.Pod, error) {
+func (h *Hvnr) preparePodOnNode(node corev1.Node, hlpPodConfig NodeExecHelperPodConfig) (*corev1.Pod, error) {
 	// Add pod deletion to shutdown sequence list (in case of Ctrl+C exit)
-	AddShutdownFunction(func() { _ = h.PurgePod(namespace, name, 10, metav1.DeletePropagationBackground) })
+	AddShutdownFunction(func() {
+		_ = h.PurgePod(hlpPodConfig.namespace, hlpPodConfig.podName, 10, metav1.DeletePropagationBackground)
+	})
 
 	// Pod configuration
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:        hlpPodConfig.podName,
+			Namespace:   hlpPodConfig.namespace,
+			Annotations: hlpPodConfig.Annotations,
 		},
 		Spec: corev1.PodSpec{
 			NodeSelector: map[string]string{
@@ -135,9 +166,10 @@ func (h *Hvnr) preparePodOnNode(node corev1.Node, namespace string, name string,
 			Containers: []corev1.Container{
 				{
 					Name:            "node-exec-container",
-					Image:           containerImage,
+					Image:           hlpPodConfig.ContainerImage,
+					Command:         hlpPodConfig.ContainerCmd,
+					Args:            hlpPodConfig.ContainerArgs,
 					ImagePullPolicy: corev1.PullIfNotPresent,
-					Stdin:           useStdin,
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: pointer.Bool(true),
 					},
@@ -157,22 +189,22 @@ func (h *Hvnr) preparePodOnNode(node corev1.Node, namespace string, name string,
 	}
 
 	// Create pod in given namespace based on configuration
-	logf(Verbose, "Creating temporary pod *%s* in namespace *%s*", name, namespace)
-	pod, err := h.client.CoreV1().Pods(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	logf(Verbose, "Creating temporary pod _%s_/*%s*", hlpPodConfig.namespace, hlpPodConfig.podName)
+	pod, err := h.client.CoreV1().Pods(hlpPodConfig.namespace).Create(h.ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	logf(Verbose, "Waiting for temporary pod to be started...")
-	if err := h.waitForPodReadiness(namespace, pod, timeoutSeconds); err != nil {
+	if err := h.waitForPodReadiness(pod, hlpPodConfig.WaitTimeout); err != nil {
 		return nil, err
 	}
 
 	return pod, nil
 }
 
-func (h *Hvnr) waitForPodReadiness(namespace string, pod *corev1.Pod, timeoutSeconds int) error {
-	watcher, err := h.client.CoreV1().Pods(namespace).Watch(context.TODO(), metav1.SingleObject(pod.ObjectMeta))
+func (h *Hvnr) waitForPodReadiness(pod *corev1.Pod, waitTimeout time.Duration) error {
+	watcher, err := h.client.CoreV1().Pods(pod.Namespace).Watch(h.ctx, metav1.SingleObject(pod.ObjectMeta))
 	if err != nil {
 		return err
 	}
@@ -196,7 +228,7 @@ func (h *Hvnr) waitForPodReadiness(namespace string, pod *corev1.Pod, timeoutSec
 		}
 	}(watcher)
 
-	timeout := time.After(time.Duration(timeoutSeconds) * time.Second)
+	timeout := time.After(waitTimeout)
 
 	for {
 		select {
@@ -209,10 +241,10 @@ func (h *Hvnr) waitForPodReadiness(namespace string, pod *corev1.Pod, timeoutSec
 				description = "Unable to provide further details regarding the state of the pod."
 			}
 
-			return fmt.Errorf("Giving up waiting for pod %s in namespace %s to become ready within %s: %w",
+			return fmt.Errorf("Giving up waiting for pod %s in namespace %s to become ready within %v: %w",
 				pod.Name,
 				pod.Namespace,
-				text.Plural(timeoutSeconds, "second"),
+				waitTimeout,
 				fmt.Errorf("status of pod at the moment of the timeout:\n\n%s", description),
 			)
 		}


### PR DESCRIPTION
Drop the assumtion that Stdin and TTY is the default and let the user specify
the usage of Stdin redirect and TTY setup using command-line flags.

Deprecate the `--no-tty` flag.

Update the long description of both `node-exec` and `pod-exec`.

Fix the bug that pod exec didn't work through Teleport.

Refactored the command-line flag setup and handling.

Refactored the exec functions to accept config structs.

Fix issue with exec and TTY over teleport by making sure to not set stderr when using TTY for exec over teleport.