### PR TITLE
Fix GoReleaser config warning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,7 @@ checksum:
   name_template: 'checksums.txt'
 
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 
 release:
   name_template: "{{.ProjectName}} release v{{.Version}}"


### PR DESCRIPTION
Use `verstion_template` instead of old name.
