### PR TITLE
Fix progress bar rounding at near-100% usage

### DIFF
--- a/internal/cmd/top.go
+++ b/internal/cmd/top.go
@@ -495,7 +495,7 @@ func renderProgressBar(value int64, max int64, caption string, text string, leng
 
 	width := length - len(text) - len(caption)
 	usage := float64(value) / float64(max)
-	marks := int(usage * float64(width))
+	marks := int(math.Round(usage * float64(width)))
 
 	var buf bytes.Buffer
 

--- a/internal/cmd/top_test.go
+++ b/internal/cmd/top_test.go
@@ -96,5 +96,34 @@ var _ = Describe("usage details string rendering", func() {
 ╵
 `))
 		})
+
+		It("should fill progress bar completely when percentage rounds to 100.0%", func() {
+			Expect(term.GetTerminalWidth()).To(BeEquivalentTo(120))
+
+			// Test case: 3199/3200 = 99.96875% rounds to "100.0%" in display
+			// Without rounding, this would show 31/32 blocks (bug)
+			// With rounding, this shows 32/32 blocks (fixed)
+			output := RenderNodeDetails(&TopDetails{
+				Nodes: map[string]NodeDetails{
+					"test-node": {
+						TotalCPU:    3200,
+						TotalMemory: 3200000,
+						UsedCPU:     3199, // 99.96875% - rounds to 100.0% in %.1f format
+						UsedMemory:  3199000, // Same ratio for memory
+						LoadAvg:     []float64{3.2, 3.2, 3.2},
+					},
+				},
+			})
+
+			// When the percentage displays as "100.0%", the bar should look complete
+			// The fix ensures we use math.Round instead of truncation
+			Expect(output).To(ContainSubstring("100.0%"))
+
+			// Verify the bars are completely filled (32 blocks for the calculated width)
+			// With the old code (truncation): 99.96875% * 32 = 31.99 → 31 blocks (bug!)
+			// With the fix (rounding): 99.96875% * 32 = 31.99 → 32 blocks (correct!)
+			Expect(output).To(MatchRegexp(`CPU ■{32}\s+100\.0%`))
+			Expect(output).To(MatchRegexp(`Memory ■{20}\s+3\.1 MiB/3\.1 MiB`))
+		})
 	})
 })


### PR DESCRIPTION
## Summary
- Fixed integer truncation in progress bar rendering where 99.96875% usage showed "100.0%" text but only 31/32 filled blocks
- Changed `int(percent * barWidth)` to `int(math.Round(percent * barWidth))` so 31.99 correctly rounds to 32

Fixes #212

## Test plan
- [ ] `go test ./internal/cmd/` passes (6/6 specs)
- [ ] Added test case for 99.96875% confirming filled blocks equal bar width when percentage rounds to 100%
<!-- sweep:amend:attestation -->
[Failing tests before](https://github.com/kimjune01/sweep/blob/23921dc8df9cec4458a5601d1ad8a46eefbc29ee/attestations/homeport-havener/issue-1033-before.txt) / [Passing tests after](https://github.com/kimjune01/sweep/blob/23921dc8df9cec4458a5601d1ad8a46eefbc29ee/attestations/homeport-havener/issue-1033-after.txt) / [How the tests ran](https://github.com/kimjune01/sweep/blob/23921dc8df9cec4458a5601d1ad8a46eefbc29ee/attestations/homeport-havener/issue-1033-manifest.json)
<!-- /sweep:amend:attestation -->

<!-- sweep:compose -->
_Sweep attestation `bc1b6d7490c5` — see the receipts footer below._
<!-- /sweep:compose -->




